### PR TITLE
OPEN: Port GitLab CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Check Gitlab CI
         uses: pulp-platform/pulp-actions/gitlab-ci@v2
         # Skip on forks or pull requests from forks due to missing secrets.
-        if: github.repository == 'pulp-platform/cheshire' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           domain: iis-git.ee.ethz.ch
           repo: github-mirror/Deeploy


### PR DESCRIPTION
Ciao Moritz,

Here is a PR to add the GitHub Action to push to the [mirror GitLab repo](https://iis-git.ee.ethz.ch/github-mirror/Deeploy). 

I registered a runner to the mirror repo. It runs on fenga8 and passes the CI (you can check on my fork). I think that all I need from you (except the review) is to add the `GITLAB_TOKEN` action secret to the original repo. I think you should be able to see the secrets from my fork (I ticked an option for that).

Let me know if you need anything else.