### PR TITLE
Fix Generic Softmax Kernel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -563,7 +563,7 @@ run_generic_test_kernels: # This job runs in the test stage.
   stage: test # It only starts when the job in the build stage completes successfully.
   parallel:
     matrix:
-    - TEST: [Adder, MultIO, test1DConvolution, test2DConvolution, test1DDWConvolution, test2DDWConvolution, test1DPad, test2DPad, testGEMM, testMatMul, testMatMulAdd, testMaxPool, testRQConv, testRQMatMul, testReduceSum, testReduceMean, testSlice, testRequantizedDWConv, test2DRequantizedConv]
+    - TEST: [Adder, MultIO, test1DConvolution, test2DConvolution, test1DDWConvolution, test2DDWConvolution, test1DPad, test2DPad, testGEMM, testMatMul, testMatMulAdd, testMaxPool, testRQConv, testRQMatMul, testReduceSum, testReduceMean, testSlice, testRequantizedDWConv, test2DRequantizedConv, iSoftmax]
   script:
     - !reference [.setup_test, script]
     - python testRunner_generic.py -t ./Tests/$TEST --toolchain=$TOOLCHAIN --toolchain_install_dir=$LLVM_INSTALL_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog
+
+## Unreleased
+
+### Fixed
+- Fix broken softmax kernel for generic platform ([#2](https://github.com/pulp-platform/Deeploy/pull/2)).

--- a/TargetLibraries/Generic/src/Softmax_s8.c
+++ b/TargetLibraries/Generic/src/Softmax_s8.c
@@ -38,7 +38,8 @@ void Softmax_s8_s8(int8_t *data_in, int8_t *data_out, uint32_t size,
                    uint32_t lastDimLength, int32_t coeffA, int32_t coeffB,
                    int64_t coeffC, int32_t log2, uint32_t n_levels) {
 
-  int8_t xTilde, z, p;
+  int8_t z;
+  int16_t xTilde, p;
   uint32_t y_sum;
   int8_t x_max;
   uint32_t *y = (uint32_t *)deeploy_malloc(sizeof(int32_t) * lastDimLength);
@@ -52,9 +53,10 @@ void Softmax_s8_s8(int8_t *data_in, int8_t *data_out, uint32_t size,
       }
     }
     for (uint32_t j = 0; j < lastDimLength; j++) {
-      xTilde = (int8_t)(data_in[j + i * lastDimLength] - x_max);
-      z = (int8_t) - (xTilde / log2);
-      p = (int8_t)(xTilde + z * log2);
+      xTilde = (data_in[j + i * lastDimLength] - x_max);
+      z = (int8_t)(-(xTilde / log2));
+      z = CLAMP(z, 0, 31);
+      p = (int16_t)(xTilde + z * log2);
       y[j] = (uint32_t)((uint64_t)(coeffA * ((p + coeffB) * (p + coeffB)) +
                                    coeffC) >>
                         (z));


### PR DESCRIPTION
This PR fixes the softmax kernel for the generic platform. The kernel is now aligned with the well tested implementation of PULPOpen. Furthermore, the `iSoftmax` test is added to the internal GitLab CI for the generic platform.

## How to Reproduce
```
cd DeeployTest/
python testRunner_generic.py -t Tests/iSoftmax
```