### PR TITLE
OPEN: GitHub-based CI/CD Flow

### DIFF
--- a/.github/workflows/BuildDocker.yml
+++ b/.github/workflows/BuildDocker.yml
@@ -1,0 +1,40 @@
+name: BuildDocker
+
+on: 
+  # push:
+  # pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-docker:
+    permissions: write-all
+    name: Deploy Docker image
+    runs-on: ubuntu-22.04
+    steps:
+      # Free up disk space on Github-hosted runner
+      - name: Disk usage
+        run: df -h
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+      - name: Disk usage after freeing up space
+        run: df -h
+      # Actually build the Docker container
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - name: GHCR Log-in
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Container/Dockerfile
+          push: true
+          tags: ghcr.io/victor-jung/deeploy:main

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,687 @@
+name: CI
+
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  build-deeploy:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+  
+  
+  ### Generic Tests ###
+  generic-kernels:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - Adder
+          - MultIO
+          - test1DConvolution
+          - test2DConvolution
+          - test1DDWConvolution
+          - test2DDWConvolution
+          - test1DPad
+          - test2DPad
+          - testGEMM
+          - testMatMul
+          - testMatMulAdd
+          - testMaxPool
+          - testRQConv
+          - testRQMatMul
+          - testReduceSum
+          - testReduceMean
+          - testSlice
+          - testRequantizedDWConv
+          - test2DRequantizedConv    
+    uses: ./.github/workflows/TestRunnerGeneric.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+
+  generic-models:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - simpleRegression
+          - WaveFormer
+          - simpleCNN
+          - ICCT
+          - ICCT_ITA
+          - ICCT_8
+          - ICCT_ITA_8
+          - miniMobileNet
+          - miniMobileNetv2
+    uses: ./.github/workflows/TestRunnerGeneric.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+  
+
+  ### CortexM Tests ###
+  cortexm-kernels:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - Adder
+          - MultIO
+          - test1DPad
+          - test2DPad
+          - testMatMul
+          - testMatMulAdd
+          - testMaxPool
+          - testRQConv
+          - testReduceSum
+          - testReduceMean
+          - testSlice  
+    uses: ./.github/workflows/TestRunnerCortexM.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+
+  cortexm-models:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - simpleRegression
+          - WaveFormer  
+    uses: ./.github/workflows/TestRunnerCortexM.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+
+
+  ### Mempool Tests ###
+  mempool-kernels:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - Adder
+          - MultIO
+          - test1DConvolution
+          - test2DConvolution
+          - test1DDWConvolution
+          - test2DDWConvolution
+          - test1DPad
+          - test2DPad
+          - testGEMM
+          - testMatMul
+          - testMatMulAdd
+          - testMaxPool
+          - testRQConv
+          - testRQGEMM
+          - testRQMatMul
+          - testReduceSum
+          - testReduceMean
+          - testSlice
+          - testRequantizedDWConv
+          - test2DRequantizedConv
+    uses: ./.github/workflows/TestRunnerMempool.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+
+  mempool-models:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - simpleRegression
+          - simpleCNN
+          - ICCT
+          - ICCT_ITA
+          - ICCT_8
+          - ICCT_ITA_8
+          - miniMobileNet
+          - miniMobileNetv2
+    uses: ./.github/workflows/TestRunnerMempool.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+
+
+  ### Siracusa Tests ###
+  siracusa-kernels:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - Adder
+          - MultIO
+          - test1DPad
+          - test2DPad
+          - testMatMul
+          - testMatMulAdd
+          - testRequantizedDWConv
+          - test2DRequantizedConv
+          - iSoftmax
+          - testConcat
+          - testRMSNorm
+          - trueIntegerDivSandwich
+          - Hardswish
+          - RQHardswish
+          - testBacktracking
+    uses: ./.github/workflows/TestRunnerSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+      num-cores: 8
+
+  siracusa-models:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - simpleRegression
+          - miniMobileNet
+          - miniMobileNetv2
+          - Attention
+          - MLPerf/KeywordSpotting
+          - MLPerf/ImageClassification
+          - MLPerf/AnomalyDetection
+    uses: ./.github/workflows/TestRunnerSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-name }}
+      num-cores: 8
+
+  siracusa-kernels-tiled-singlebuffer-L2:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "testMatMul"
+            L1: [64000, 32000, 16000]
+          - name: "test2DRequantizedConv"
+            L1: [8000, 6000, 4000]
+          - name: "testRequantizedDWConv"
+            L1: [2561] # SCHEREMO: The implicit transpose after the conv is untiled; need at least 2560
+          - name: "iSoftmax"
+            L1: [800, 500, 300]
+          - name: "testConcat"
+            L1: [32000, 16000, 8000]
+          - name: "testRMSNorm"
+            L1: [2048, 1024, 512]
+          - name: "Hardswish"
+            L1: [750]
+          - name: "RQHardswish"
+            L1: [750]
+        num-cores:
+          - 8
+    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+
+  siracusa-kernels-tiled-doublebuffer-L2:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "testMatMul"
+            L1: [64000, 32000, 16000]
+          - name: "test2DRequantizedConv"
+            L1: [8000, 6000, 5000]
+          - name: "testRequantizedDWConv"
+            L1: [5121] # SCHEREMO: The implicit transpose after the conv is untiled; need at least 2560 * 2 for DB
+          - name: "iSoftmax"
+            L1: [1600, 1000, 600]
+          - name: "testConcat"
+            L1: [64000, 32000, 16000]
+          - name: "testRMSNorm"
+            L1: [4096, 2048, 1024]
+          - name: "Hardswish"
+            L1: [750]
+          - name: "RQHardswish"
+            L1: [750]
+          - name: "microLlama/microLlama1"
+            L1: [60000, 20000, 10000]
+          - name: "microLlama/microLlama8"
+            L1: [60000, 20000, 10000]
+          - name: "microLlama/microLlama8_parallel"
+            L1: [60000, 20000, 10000]
+        num-cores:
+          - 8
+        double-buffer:
+          - true
+    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      double-buffer: ${{ matrix.double-buffer }}
+    
+  siracusa-models-tiled-singlebuffer-L2:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "simpleRegression"
+            L1: [45000, 30000, 15000]
+          - name: "miniMobileNet"
+            L1: [60000, 12000, 6000, 3000]
+          - name: "miniMobileNetv2"
+            L1: [60000, 16000, 12000, 8000]
+          - name: "Attention"
+            L1: [60000, 10000, 5000]
+          - name: "microLlama/microLlama1"
+            L1: [60000, 10000, 5000]
+          - name: "microLlama/microLlama8"
+            L1: [60000, 10000, 5000]
+          - name: "microLlama/microLlama8_parallel"
+            L1: [60000, 10000, 5000]
+          - name: "MLPerf/KeywordSpotting"
+            L1: [64000]
+          - name: "MLPerf/ImageClassification"
+            L1: [64000]
+          - name: "MLPerf/AnomalyDetection"
+            L1: [64000]
+        num-cores:
+          - 8
+    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+
+  siracusa-models-tiled-singlebuffer-L3:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "simpleRegression"
+            L1: [45000, 30000, 16000] # SCHEREMO: 15000 leads to non-2d transfers in L3!
+          - name: "miniMobileNet"
+            L1: [60000, 12000, 6000] # SCHEREMO: 3000 leads to non-2d transfers in L3!
+          - name: "miniMobileNetv2"
+            L1: [60000, 16000, 12000, 8000]
+          - name: "Attention"
+            L1: [60000, 10000, 5000, 2500]
+          - name: "Transformer"
+            L1: [60000, 30000, 15000]
+          - name: "microLlama/microLlama1"
+            L1: [60000, 10000, 5000]
+        num-cores:
+          - 8
+        default-memory-level:
+          - "L3"
+    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      default-memory-level: ${{ matrix.default-memory-level }}
+
+  siracusa-models-tiled-doublebuffer-L3:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "simpleRegression"
+            L1: [60000, 45000, 30000]
+          - name: "miniMobileNet"
+            L1: [60000, 24000, 12000, 6000]
+          - name: "miniMobileNetv2"
+            L1: [60000, 32000, 24000, 16000]
+          - name: "Attention"
+            L1: [60000, 20000, 10000, 5000]
+          - name: "Transformer"
+            L1: [60000, 30000, 15000]
+        num-cores:
+          - 8
+        double-buffer:
+          - true
+        default-memory-level:
+          - "L3"
+    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      double-buffer: ${{ matrix.double-buffer }}
+      default-memory-level: ${{ matrix.default-memory-level }}
+
+  siracusa-neureka-kernels-tiled-singlebuffer-L2:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "testRequantizedLinear"
+            L1: [16000]
+          - name: "testPointwise"
+            L1: [32000]
+          - name: "testPointwiseConvBNReLU"
+            L1: [32000]
+          - name: "testPointwiseUnsignedWeights"
+            L1: [32000]
+        num-cores:
+          - 8
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+
+  siracusa-neureka-kernels-tiled-doublebuffer-L2:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "testRequantizedLinear"
+            L1: [16000]
+          - name: "testPointwise"
+            L1: [32000]
+          - name: "testPointwiseConvBNReLU"
+            L1: [32000]
+          - name: "testPointwiseUnsignedWeights"
+            L1: [32000]
+        num-cores:
+          - 8
+        double-buffer:
+          - true
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      double-buffer: ${{ matrix.double-buffer }}
+
+  siracusa-neureka-models-tiled-singlebuffer-L3:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "miniMobileNet"
+            L1: [2000] # LMACAN: 1000 leads to non-2d transfers in L3!
+          - name: "Attention"
+            L1: [2500]
+          - name: "Transformer"
+            L1: [15000]
+          - name: "microLlama/microLlama1"
+            L1: [10000]
+        num-cores:
+          - 8
+        default-memory-level:
+          - "L3"
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      default-memory-level: ${{ matrix.default-memory-level }}
+
+  siracusa-neureka-models-tiled-doublebuffer-L3:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "miniMobileNet"
+            L1: [2000] # LMACAN: 1000 leads to non-2d transfers in L3!
+          - name: "Attention"
+            L1: [5000]
+          - name: "Transformer"
+            L1: [30000]
+        num-cores:
+          - 8
+        double-buffer:
+          - true
+        default-memory-level:
+          - "L3"
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      double-buffer: ${{ matrix.double-buffer }}
+      default-memory-level: ${{ matrix.default-memory-level }}
+
+  siracusa-neureka-kernels-tiled-singlebuffer-L2-wmem:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "testRequantizedLinear"
+            L1: [16000]
+          - name: "testPointwise"
+            L1: [32000]
+          - name: "testPointwiseConvBNReLU"
+            L1: [32000]
+          - name: "testPointwiseUnsignedWeights"
+            L1: [32000]
+        num-cores:
+          - 8
+        neureka-wmem:
+          - true
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      neureka-wmem: ${{ matrix.neureka-wmem }}
+
+  siracusa-neureka-models-tiled-doublebuffer-L3-wmem:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-data: 
+          - name: "miniMobileNet"
+            L1: [2000] # LMACAN: 1000 leads to non-2d transfers in L3!
+          - name: "Attention"
+            L1: [2500]
+          - name: "Transformer"
+            L1: [30000]
+          - name: "microLlama/microLlama1"
+            L1: [10000]
+        num-cores:
+          - 8
+        double-buffer:
+          - true
+        default-memory-level:
+          - "L3"
+        neureka-wmem:
+          - true
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    with:
+      test-name: ${{ matrix.test-data.name }}
+      num-cores: ${{ matrix.num-cores }}
+      L1: ${{ toJson(matrix.test-data.L1) }}
+      double-buffer: ${{ matrix.double-buffer }}
+      default-memory-level: ${{ matrix.default-memory-level }}
+      neureka-wmem: ${{ matrix.neureka-wmem }}
+
+
+  ### Deeploy Extension and Internal Tests ###
+  deeploy-state-serialization:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["simpleRegression"]
+        platform: ['QEMU-ARM', 'Siracusa', 'MemPool', 'Generic']
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python deeployStateEqualityTest.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+        shell: bash
+
+  deeploy-memory-level-extension:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["simpleRegression"]
+        platform: ['QEMU-ARM', 'Siracusa', 'MemPool', 'Generic']
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testMemoryLevelExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+        shell: bash
+
+  deeploy-tiler-extension:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["simpleRegression", "simpleCNN", "testMatMul", "testMaxPool"]
+        platform: ['Siracusa']
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testTilerExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+        shell: bash
+
+  deeploy-tiler-extension-fail:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["simpleRegression", "simpleCNN", "testMatMul", "testMaxPool"]
+        platform: ['Siracusa']
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testTilerExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }} --l1 2000 --shouldFail
+        shell: bash
+
+  deeploy-memory-allocation-extension:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["simpleRegression", "simpleCNN", "miniMobileNet", "miniMobileNetv2", "testMatMul", "testMaxPool"]
+        platform: ["Siracusa"]
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testTilerExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+        shell: bash
+
+  deeploy-typing:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testTypes.py
+        shell: bash
+
+  deeploy-regex-matching:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testRegexMatching.py
+        shell: bash
+
+  linting:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: |
+          pip install -e .
+          cd DeeployTest
+      - name: Format Python
+        run: |
+          yapf -rpd -e "third_party/" -e "install/" -e "toolchain/" .
+        shell: bash
+      - name: Format Python Imports
+        run: |
+          isort --sg "**/third_party/*"  --sg "install/*" --sg "toolchain/*" ./ -c -v
+          autoflake -c -r --remove-all-unused-imports --ignore-init-module-imports --exclude "*/third_party/**" ./
+        shell: bash
+      - name: Format C
+        run: |
+          python scripts/run_clang_format.py -e "*/third_party/*" -e "*/install/*" -e "*/toolchain/*" -ir --clang-format-executable=${LLVM_INSTALL_DIR}/bin/clang-format ./ scripts
+        shell: bash
+      - name: Format Python Licenses
+        run: |
+          grep -Lr "SPDX-License-Identifier: Apache-2.0" --exclude-dir="toolchain" --exclude-dir="install" --exclude-dir=".git" . --exclude-dir="third_party" --exclude-dir="TEST_*" --exclude "run_clang_format.py" | grep ".*\.py$" || [[ $? == 1 ]]        
+        shell: bash
+      - name: Format C Licenses
+        run: |
+          grep -Lr "SPDX-License-Identifier: Apache-2.0" --exclude-dir="toolchain" --exclude-dir="install" --exclude-dir=".git" . --exclude-dir="third_party" --exclude-dir="TEST_*" --exclude-dir="runtime" | grep ".*\.c$" || [[ $? == 1 ]]        
+        shell: bash
+      - name: Format C Header Licenses
+        run: |
+          grep -Lr "SPDX-License-Identifier: Apache-2.0" --exclude-dir="toolchain" --exclude-dir="install" --exclude-dir=".git" . --exclude-dir="third_party" --exclude-dir="TEST_*" --exclude-dir="runtime" | grep ".*\.h$" || [[ $? == 1 ]]
+        shell: bash
+  
+
+
+        

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,242 +22,224 @@ jobs:
   
   ### Generic Tests ###
   generic-kernels:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - Adder
-          - MultIO
-          - test1DConvolution
-          - test2DConvolution
-          - test1DDWConvolution
-          - test2DDWConvolution
-          - test1DPad
-          - test2DPad
-          - testGEMM
-          - testMatMul
-          - testMatMulAdd
-          - testMaxPool
-          - testRQConv
-          - testRQMatMul
-          - testReduceSum
-          - testReduceMean
-          - testSlice
-          - testRequantizedDWConv
-          - test2DRequantizedConv    
     uses: ./.github/workflows/TestRunnerGeneric.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        Adder
+        MultIO
+        test1DConvolution
+        test2DConvolution
+        test1DDWConvolution
+        test2DDWConvolution
+        test1DPad
+        test2DPad
+        testGEMM
+        testMatMul
+        testMatMulAdd
+        testMaxPool
+        testRQConv
+        testRQMatMul
+        testReduceSum
+        testReduceMean
+        testSlice
+        testRequantizedDWConv
+        test2DRequantizedConv
 
   generic-models:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - simpleRegression
-          - WaveFormer
-          - simpleCNN
-          - ICCT
-          - ICCT_ITA
-          - ICCT_8
-          - ICCT_ITA_8
-          - miniMobileNet
-          - miniMobileNetv2
     uses: ./.github/workflows/TestRunnerGeneric.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        simpleRegression
+        WaveFormer
+        simpleCNN
+        ICCT
+        ICCT_ITA
+        ICCT_8
+        ICCT_ITA_8
+        miniMobileNet
+        miniMobileNetv2
   
 
   ### CortexM Tests ###
-  cortexm-kernels:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - Adder
-          - MultIO
-          - test1DPad
-          - test2DPad
-          - testMatMul
-          - testMatMulAdd
-          - testMaxPool
-          - testRQConv
-          - testReduceSum
-          - testReduceMean
-          - testSlice  
+  cortexm-kernels: 
     uses: ./.github/workflows/TestRunnerCortexM.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        Adder
+        MultIO
+        test1DPad
+        test2DPad
+        testMatMul
+        testMatMulAdd
+        testMaxPool
+        testRQConv
+        testReduceSum
+        testReduceMean
+        testSlice
 
-  cortexm-models:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - simpleRegression
-          - WaveFormer  
+  cortexm-models: 
     uses: ./.github/workflows/TestRunnerCortexM.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        simpleRegression
+        WaveFormer 
 
 
   ### Mempool Tests ###
   mempool-kernels:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - Adder
-          - MultIO
-          - test1DConvolution
-          - test2DConvolution
-          - test1DDWConvolution
-          - test2DDWConvolution
-          - test1DPad
-          - test2DPad
-          - testGEMM
-          - testMatMul
-          - testMatMulAdd
-          - testMaxPool
-          - testRQConv
-          - testRQGEMM
-          - testRQMatMul
-          - testReduceSum
-          - testReduceMean
-          - testSlice
-          - testRequantizedDWConv
-          - test2DRequantizedConv
     uses: ./.github/workflows/TestRunnerMempool.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+          Adder
+          MultIO
+          test1DConvolution
+          test2DConvolution
+          test1DDWConvolution
+          test2DDWConvolution
+          test1DPad
+          test2DPad
+          testGEMM
+          testMatMul
+          testMatMulAdd
+          testMaxPool
+          testRQConv
+          testRQGEMM
+          testRQMatMul
+          testReduceSum
+          testReduceMean
+          testSlice
+          testRequantizedDWConv
+          test2DRequantizedConv
 
   mempool-models:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - simpleRegression
-          - simpleCNN
-          - ICCT
-          - ICCT_ITA
-          - ICCT_8
-          - ICCT_ITA_8
-          - miniMobileNet
-          - miniMobileNetv2
     uses: ./.github/workflows/TestRunnerMempool.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        simpleRegression
+        simpleCNN
+        ICCT
+        ICCT_ITA
+        ICCT_8
+        ICCT_ITA_8
+        miniMobileNet
+        miniMobileNetv2
 
 
   ### Siracusa Tests ###
   siracusa-kernels:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - Adder
-          - MultIO
-          - test1DPad
-          - test2DPad
-          - testMatMul
-          - testMatMulAdd
-          - testRequantizedDWConv
-          - test2DRequantizedConv
-          - iSoftmax
-          - testConcat
-          - testRMSNorm
-          - trueIntegerDivSandwich
-          - Hardswish
-          - RQHardswish
-          - testBacktracking
     uses: ./.github/workflows/TestRunnerSiracusa.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        Adder
+        MultIO
+        test1DPad
+        test2DPad
+        testMatMul
+        testMatMulAdd
+        testRequantizedDWConv
+        test2DRequantizedConv
+        iSoftmax
+        testConcat
+        testRMSNorm
+        trueIntegerDivSandwich
+        Hardswish
+        RQHardswish
+        testBacktracking
       num-cores: 8
 
   siracusa-models:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - simpleRegression
-          - miniMobileNet
-          - miniMobileNetv2
-          - Attention
-          - MLPerf/KeywordSpotting
-          - MLPerf/ImageClassification
-          - MLPerf/AnomalyDetection
     uses: ./.github/workflows/TestRunnerSiracusa.yml
     with:
-      test-name: ${{ matrix.test-name }}
+      test-names: |
+        simpleRegression
+        miniMobileNet
+        miniMobileNetv2
+        Attention
+        MLPerf/KeywordSpotting
+        MLPerf/ImageClassification
+        MLPerf/AnomalyDetection
       num-cores: 8
 
   siracusa-kernels-tiled-singlebuffer-L2:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-data: 
-          - name: "testMatMul"
-            L1: [64000, 32000, 16000]
-          - name: "test2DRequantizedConv"
-            L1: [8000, 6000, 4000]
-          - name: "testRequantizedDWConv"
-            L1: [2561] # SCHEREMO: The implicit transpose after the conv is untiled; need at least 2560
-          - name: "iSoftmax"
-            L1: [800, 500, 300]
-          - name: "testConcat"
-            L1: [32000, 16000, 8000]
-          - name: "testRMSNorm"
-            L1: [2048, 1024, 512]
-          - name: "Hardswish"
-            L1: [750]
-          - name: "RQHardswish"
-            L1: [750]
-        num-cores:
-          - 8
-    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    uses: ./.github/workflows/TestRunnerTiledSiracusaSequential.yml
     with:
-      test-name: ${{ matrix.test-data.name }}
-      num-cores: ${{ matrix.num-cores }}
-      L1: ${{ toJson(matrix.test-data.L1) }}
+      tests-config: |
+        [
+          {
+            "name": "testMatMul",
+            "L1": [64000, 32000, 16000]
+          },
+          {
+            "name": "test2DRequantizedConv",
+            "L1": [8000, 6000, 4000]
+          },
+          {
+            "name": "testRequantizedDWConv",
+            "L1": [2561]
+          },
+          {
+            "name": "iSoftmax",
+            "L1": [800, 500, 300]
+          },
+          {
+            "name": "testConcat",
+            "L1": [32000, 16000, 8000]
+          },
+          {
+            "name": "testRMSNorm",
+            "L1": [2048, 1024, 512]
+          },
+          {
+            "name": "Hardswish",
+            "L1": [750]
+          },
+          {
+            "name": "RQHardswish",
+            "L1": [750]
+          }
+        ]
+      num-cores: 8
 
   siracusa-kernels-tiled-doublebuffer-L2:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-data: 
-          - name: "testMatMul"
-            L1: [64000, 32000, 16000]
-          - name: "test2DRequantizedConv"
-            L1: [8000, 6000, 5000]
-          - name: "testRequantizedDWConv"
-            L1: [5121] # SCHEREMO: The implicit transpose after the conv is untiled; need at least 2560 * 2 for DB
-          - name: "iSoftmax"
-            L1: [1600, 1000, 600]
-          - name: "testConcat"
-            L1: [64000, 32000, 16000]
-          - name: "testRMSNorm"
-            L1: [4096, 2048, 1024]
-          - name: "Hardswish"
-            L1: [750]
-          - name: "RQHardswish"
-            L1: [750]
-          - name: "microLlama/microLlama1"
-            L1: [60000, 20000, 10000]
-          - name: "microLlama/microLlama8"
-            L1: [60000, 20000, 10000]
-          - name: "microLlama/microLlama8_parallel"
-            L1: [60000, 20000, 10000]
-        num-cores:
-          - 8
-        double-buffer:
-          - true
-    uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    uses: ./.github/workflows/TestRunnerTiledSiracusaSequential.yml
     with:
-      test-name: ${{ matrix.test-data.name }}
-      num-cores: ${{ matrix.num-cores }}
-      L1: ${{ toJson(matrix.test-data.L1) }}
-      double-buffer: ${{ matrix.double-buffer }}
+      tests-config: |
+        [
+          {
+            "name": "testMatMul",
+            "L1": [64000, 32000, 16000]
+          },
+          {
+            "name": "test2DRequantizedConv",
+            "L1": [8000, 6000, 5000]
+          },
+          {
+            "name": "testRequantizedDWConv",
+            "L1": [5121]
+          },
+          {
+            "name": "iSoftmax",
+            "L1": [1600, 1000, 600]
+          },
+          {
+            "name": "testConcat",
+            "L1": [64000, 32000, 16000]
+          },
+          {
+            "name": "testRMSNorm",
+            "L1": [4096, 2048, 1024]
+          },
+          {
+            "name": "Hardswish",
+            "L1": [750]
+          },
+          {
+            "name": "RQHardswish",
+            "L1": [750]
+          }
+        ]
+      num-cores: 8
+      double-buffer: true
     
   siracusa-models-tiled-singlebuffer-L2:
     strategy:
@@ -335,6 +317,12 @@ jobs:
             L1: [60000, 20000, 10000, 5000]
           - name: "Transformer"
             L1: [60000, 30000, 15000]
+          - name: "microLlama/microLlama1"
+            L1: [60000, 20000, 10000]
+          - name: "microLlama/microLlama8"
+            L1: [60000, 20000, 10000]
+          - name: "microLlama/microLlama8_parallel"
+            L1: [60000, 20000, 10000]
         num-cores:
           - 8
         double-buffer:
@@ -350,49 +338,53 @@ jobs:
       default-memory-level: ${{ matrix.default-memory-level }}
 
   siracusa-neureka-kernels-tiled-singlebuffer-L2:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-data: 
-          - name: "testRequantizedLinear"
-            L1: [16000]
-          - name: "testPointwise"
-            L1: [32000]
-          - name: "testPointwiseConvBNReLU"
-            L1: [32000]
-          - name: "testPointwiseUnsignedWeights"
-            L1: [32000]
-        num-cores:
-          - 8
-    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
     with:
-      test-name: ${{ matrix.test-data.name }}
-      num-cores: ${{ matrix.num-cores }}
-      L1: ${{ toJson(matrix.test-data.L1) }}
+      tests-config: |
+        [
+          {
+            "name": "testRequantizedLinear",
+            "L1": [16000]
+          },
+          {
+            "name": "testPointwise",
+            "L1": [32000]
+          },
+          {
+            "name": "testPointwiseConvBNReLU",
+            "L1": [32000]
+          },
+          {
+            "name": "testPointwiseUnsignedWeights",
+            "L1": [32000]
+          }
+        ]
+      num-cores: 8
 
   siracusa-neureka-kernels-tiled-doublebuffer-L2:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-data: 
-          - name: "testRequantizedLinear"
-            L1: [16000]
-          - name: "testPointwise"
-            L1: [32000]
-          - name: "testPointwiseConvBNReLU"
-            L1: [32000]
-          - name: "testPointwiseUnsignedWeights"
-            L1: [32000]
-        num-cores:
-          - 8
-        double-buffer:
-          - true
-    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
     with:
-      test-name: ${{ matrix.test-data.name }}
-      num-cores: ${{ matrix.num-cores }}
-      L1: ${{ toJson(matrix.test-data.L1) }}
-      double-buffer: ${{ matrix.double-buffer }}
+      tests-config: |
+        [
+          {
+            "name": "testRequantizedLinear",
+            "L1": [16000]
+          },
+          {
+            "name": "testPointwise",
+            "L1": [32000]
+          },
+          {
+            "name": "testPointwiseConvBNReLU",
+            "L1": [32000]
+          },
+          {
+            "name": "testPointwiseUnsignedWeights",
+            "L1": [32000]
+          }
+        ]
+      num-cores: 8
+      double-buffer: true
 
   siracusa-neureka-models-tiled-singlebuffer-L3:
     strategy:
@@ -444,28 +436,29 @@ jobs:
       default-memory-level: ${{ matrix.default-memory-level }}
 
   siracusa-neureka-kernels-tiled-singlebuffer-L2-wmem:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-data: 
-          - name: "testRequantizedLinear"
-            L1: [16000]
-          - name: "testPointwise"
-            L1: [32000]
-          - name: "testPointwiseConvBNReLU"
-            L1: [32000]
-          - name: "testPointwiseUnsignedWeights"
-            L1: [32000]
-        num-cores:
-          - 8
-        neureka-wmem:
-          - true
-    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
     with:
-      test-name: ${{ matrix.test-data.name }}
-      num-cores: ${{ matrix.num-cores }}
-      L1: ${{ toJson(matrix.test-data.L1) }}
-      neureka-wmem: ${{ matrix.neureka-wmem }}
+      tests-config: |
+        [
+          {
+            "name": "testRequantizedLinear",
+            "L1": [16000]
+          },
+          {
+            "name": "testPointwise",
+            "L1": [32000]
+          },
+          {
+            "name": "testPointwiseConvBNReLU",
+            "L1": [32000]
+          },
+          {
+            "name": "testPointwiseUnsignedWeights",
+            "L1": [32000]
+          }
+        ]
+      num-cores: 8
+      neureka-wmem: true
 
   siracusa-neureka-models-tiled-doublebuffer-L3-wmem:
     strategy:
@@ -476,8 +469,8 @@ jobs:
             L1: [2000] # LMACAN: 1000 leads to non-2d transfers in L3!
           - name: "Attention"
             L1: [2500]
-          - name: "Transformer"
-            L1: [30000]
+          # - name: "Transformer"
+          #   L1: [30000]
           - name: "microLlama/microLlama1"
             L1: [10000]
         num-cores:
@@ -500,11 +493,6 @@ jobs:
 
   ### Deeploy Extension and Internal Tests ###
   deeploy-state-serialization:
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ["simpleRegression"]
-        platform: ['QEMU-ARM', 'Siracusa', 'MemPool', 'Generic']
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -518,15 +506,13 @@ jobs:
       - name: Run Test
         run: |
           cd DeeployTest
-          python deeployStateEqualityTest.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+          python deeployStateEqualityTest.py -t ./Tests/simpleRegression -p QEMU-ARM
+          python deeployStateEqualityTest.py -t ./Tests/simpleRegression -p Siracusa
+          python deeployStateEqualityTest.py -t ./Tests/simpleRegression -p MemPool
+          python deeployStateEqualityTest.py -t ./Tests/simpleRegression -p Generic
         shell: bash
 
   deeploy-memory-level-extension:
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ["simpleRegression"]
-        platform: ['QEMU-ARM', 'Siracusa', 'MemPool', 'Generic']
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -540,15 +526,13 @@ jobs:
       - name: Run Test
         run: |
           cd DeeployTest
-          python testMemoryLevelExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+          python testMemoryLevelExtension.py -t ./Tests/simpleRegression -p QEMU-ARM
+          python testMemoryLevelExtension.py -t ./Tests/simpleRegression -p Siracusa
+          python testMemoryLevelExtension.py -t ./Tests/simpleRegression -p MemPool
+          python testMemoryLevelExtension.py -t ./Tests/simpleRegression -p Generic
         shell: bash
 
   deeploy-tiler-extension:
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ["simpleRegression", "simpleCNN", "testMatMul", "testMaxPool"]
-        platform: ['Siracusa']
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -562,37 +546,17 @@ jobs:
       - name: Run Test
         run: |
           cd DeeployTest
-          python testTilerExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
-        shell: bash
-
-  deeploy-tiler-extension-fail:
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ["simpleRegression", "simpleCNN", "testMatMul", "testMaxPool"]
-        platform: ['Siracusa']
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/victor-jung/deeploy:main
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Build Deeploy
-        run: pip install -e .
-      - name: Run Test
-        run: |
-          cd DeeployTest
-          python testTilerExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }} --l1 2000 --shouldFail
+          python testTilerExtension.py -p Siracusa -t ./Tests/simpleRegression
+          python testTilerExtension.py -p Siracusa -t ./Tests/simpleCNN
+          python testTilerExtension.py -p Siracusa -t ./Tests/testMatMul
+          python testTilerExtension.py -p Siracusa -t ./Tests/testMaxPool
+          python testTilerExtension.py -p Siracusa -t ./Tests/simpleRegression --l1 2000 --shouldFail
+          python testTilerExtension.py -p Siracusa -t ./Tests/simpleCNN --l1 2000 --shouldFail
+          python testTilerExtension.py -p Siracusa -t ./Tests/testMatMul --l1 2000 --shouldFail
+          python testTilerExtension.py -p Siracusa -t ./Tests/testMaxPool --l1 2000 --shouldFail
         shell: bash
 
   deeploy-memory-allocation-extension:
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ["simpleRegression", "simpleCNN", "miniMobileNet", "miniMobileNetv2", "testMatMul", "testMaxPool"]
-        platform: ["Siracusa"]
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -606,7 +570,12 @@ jobs:
       - name: Run Test
         run: |
           cd DeeployTest
-          python testTilerExtension.py -t ./Tests/${{ matrix.name }} -p ${{ matrix.platform }}
+          python testTilerExtension.py -p Siracusa -t ./Tests/simpleRegression
+          python testTilerExtension.py -p Siracusa -t ./Tests/simpleCNN
+          python testTilerExtension.py -p Siracusa -t ./Tests/miniMobileNet
+          python testTilerExtension.py -p Siracusa -t ./Tests/miniMobileNetv2
+          python testTilerExtension.py -p Siracusa -t ./Tests/testMatMul
+          python testTilerExtension.py -p Siracusa -t ./Tests/testMaxPool
         shell: bash
 
   deeploy-typing:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,7 @@ jobs:
         testSlice
         testRequantizedDWConv
         test2DRequantizedConv
+        iSoftmax
 
   generic-models:
     uses: ./.github/workflows/TestRunnerGeneric.yml

--- a/.github/workflows/GitLabCI.yml
+++ b/.github/workflows/GitLabCI.yml
@@ -1,10 +1,13 @@
-name: gitlab-ci
+name: GitLabCI
 
-on: [ push, pull_request, workflow_dispatch ]
+on: 
+  # push:
+  # pull_request:
+  workflow_dispatch:
 
 jobs:
   gitlab-ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Gitlab CI
         uses: pulp-platform/pulp-actions/gitlab-ci@v2

--- a/.github/workflows/TestRunnerCortexM.yml
+++ b/.github/workflows/TestRunnerCortexM.yml
@@ -3,7 +3,7 @@ name: TestRunnerCortexM
 on:
   workflow_call:
     inputs:
-      test-name:
+      test-names:
         required: true
         type: string
 
@@ -21,6 +21,12 @@ jobs:
         run: pip install -e .
       - name: Run Test
         run: |
+          testNames="${{ inputs.test-names }}"
           cd DeeployTest
-          python testRunner_cortexm.py -t Tests/${{ inputs.test-name }}
+          echo "$testNames" | while IFS= read -r testName; do
+            if [[ -n "$testName" ]]; then
+              echo "Running test: $testName"
+              python testRunner_cortexm.py -t Tests/$testName
+            fi
+          done
           

--- a/.github/workflows/TestRunnerCortexM.yml
+++ b/.github/workflows/TestRunnerCortexM.yml
@@ -1,0 +1,26 @@
+name: TestRunnerCortexM
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+
+jobs:
+  test-runner-cortexm:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testRunner_cortexm.py -t Tests/${{ inputs.test-name }}
+          

--- a/.github/workflows/TestRunnerGeneric.yml
+++ b/.github/workflows/TestRunnerGeneric.yml
@@ -1,0 +1,26 @@
+name: TestRunnerGeneric
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+
+jobs:
+  test-runner-cortexm:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testRunner_generic.py -t Tests/${{ inputs.test-name }}
+          

--- a/.github/workflows/TestRunnerGeneric.yml
+++ b/.github/workflows/TestRunnerGeneric.yml
@@ -3,12 +3,12 @@ name: TestRunnerGeneric
 on:
   workflow_call:
     inputs:
-      test-name:
+      test-names:
         required: true
         type: string
 
 jobs:
-  test-runner-cortexm:
+  test-runner-generic:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -21,6 +21,12 @@ jobs:
         run: pip install -e .
       - name: Run Test
         run: |
+          testNames="${{ inputs.test-names }}"
           cd DeeployTest
-          python testRunner_generic.py -t Tests/${{ inputs.test-name }}
+          echo "$testNames" | while IFS= read -r testName; do
+            if [[ -n "$testName" ]]; then
+              echo "Running test: $testName"
+              python testRunner_generic.py -t Tests/$testName
+            fi
+          done
           

--- a/.github/workflows/TestRunnerMempool.yml
+++ b/.github/workflows/TestRunnerMempool.yml
@@ -1,0 +1,26 @@
+name: TestRunnerMempool
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+
+jobs:
+  test-runner-mempool:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          python testRunner_mempool.py -t Tests/${{ inputs.test-name }}
+          

--- a/.github/workflows/TestRunnerMempool.yml
+++ b/.github/workflows/TestRunnerMempool.yml
@@ -3,7 +3,7 @@ name: TestRunnerMempool
 on:
   workflow_call:
     inputs:
-      test-name:
+      test-names:
         required: true
         type: string
 
@@ -21,6 +21,12 @@ jobs:
         run: pip install -e .
       - name: Run Test
         run: |
+          testNames="${{ inputs.test-names }}"
           cd DeeployTest
-          python testRunner_mempool.py -t Tests/${{ inputs.test-name }}
+          echo "$testNames" | while IFS= read -r testName; do
+            if [[ -n "$testName" ]]; then
+              echo "Running test: $testName"
+              python testRunner_mempool.py -t Tests/$testName
+            fi
+          done
           

--- a/.github/workflows/TestRunnerSiracusa.yml
+++ b/.github/workflows/TestRunnerSiracusa.yml
@@ -1,0 +1,39 @@
+name: TestRunnerSiracusa
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+      num-cores:
+        required: true
+        type: number
+
+jobs:
+  test-runner-siracusa:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Cache ccache
+        id: ccache-cache
+        uses: actions/cache@v4
+        with:
+          path: /app/.ccache
+          key: ${{ runner.os }}-ccache
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          mkdir -p /app/.ccache
+          export CCACHE_DIR=/app/.ccache
+          source /app/install/pulp-sdk/configs/siracusa.sh
+          python testRunner_siracusa.py -t Tests/${{ inputs.test-name }} --cores=${{ inputs.num-cores }}
+        shell: bash
+        

--- a/.github/workflows/TestRunnerSiracusa.yml
+++ b/.github/workflows/TestRunnerSiracusa.yml
@@ -3,7 +3,7 @@ name: TestRunnerSiracusa
 on:
   workflow_call:
     inputs:
-      test-name:
+      test-names:
         required: true
         type: string
       num-cores:
@@ -30,10 +30,16 @@ jobs:
           key: ${{ runner.os }}-ccache
       - name: Run Test
         run: |
+          testNames="${{ inputs.test-names }}"
           cd DeeployTest
           mkdir -p /app/.ccache
           export CCACHE_DIR=/app/.ccache
           source /app/install/pulp-sdk/configs/siracusa.sh
-          python testRunner_siracusa.py -t Tests/${{ inputs.test-name }} --cores=${{ inputs.num-cores }}
+          echo "$testNames" | while IFS= read -r testName; do
+            if [[ -n "$testName" ]]; then
+              echo "Running test: $testName"
+              python testRunner_siracusa.py -t Tests/$testName --cores=${{ inputs.num-cores }}
+            fi
+          done
         shell: bash
         

--- a/.github/workflows/TestRunnerTiledSiracusa.yml
+++ b/.github/workflows/TestRunnerTiledSiracusa.yml
@@ -1,0 +1,57 @@
+name: TestRunnerTiledSiracusa
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+      num-cores:
+        required: false
+        default: 8
+        type: number
+      L1:
+        required: false
+        default: "[64000]"
+        type: string
+      default-memory-level:
+        required: false
+        default: "L2"
+        type: string
+      double-buffer:
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+
+  test-runner-siracusa-tiled:
+    strategy:
+      fail-fast: false
+      matrix:
+        L1: ${{ fromJSON(inputs.L1) }}
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Cache ccache
+        id: ccache-cache
+        uses: actions/cache@v4
+        with:
+          path: /app/.ccache
+          key: ${{ runner.os }}-ccache
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          mkdir -p /app/.ccache
+          export CCACHE_DIR=/app/.ccache
+          source /app/install/pulp-sdk/configs/siracusa.sh
+          python testRunner_tiled_siracusa.py -t Tests/${{ inputs.test-name }} --cores=${{ inputs.num-cores }} --l1 ${{ matrix.L1 }} --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }}
+        shell: bash
+        

--- a/.github/workflows/TestRunnerTiledSiracusaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaSequential.yml
@@ -1,19 +1,15 @@
-name: TestRunnerTiledSiracusaWithNeureka
+name: TestRunnerTiledSiracusaSequential
 
 on:
   workflow_call:
     inputs:
-      test-name:
+      tests-config:
         required: true
         type: string
       num-cores:
         required: false
         default: 8
         type: number
-      L1:
-        required: false
-        default: "[64000]"
-        type: string
       default-memory-level:
         required: false
         default: "L2"
@@ -22,18 +18,10 @@ on:
         required: false
         default: false
         type: boolean
-      neureka-wmem:
-        required: false
-        default: false
-        type: boolean
 
 jobs:
 
-  test-runner-siracusa-neureka-tiled:
-    strategy:
-      fail-fast: false
-      matrix:
-        L1: ${{ fromJSON(inputs.L1) }}
+  test-runner-siracusa-tiled:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -44,18 +32,30 @@ jobs:
           submodules: recursive
       - name: Build Deeploy
         run: pip install -e .
+      - name: Install jq
+        run: apt-get install -y jq
       - name: Cache ccache
-        id: ccache-cache-neureka
+        id: ccache-cache
         uses: actions/cache@v4
         with:
           path: /app/.ccache
-          key: ${{ runner.os }}-ccache-neureka
-      - name: Run Test
+          key: ${{ runner.os }}-ccache
+      - name: Run Tests
         run: |
           cd DeeployTest
+          echo '${{ inputs.tests-config }}' > tests.json
           mkdir -p /app/.ccache
           export CCACHE_DIR=/app/.ccache
           source /app/install/pulp-sdk/configs/siracusa.sh
-          python testRunner_tiled_siracusa_w_neureka.py -t Tests/${{ inputs.test-name }} --cores=${{ inputs.num-cores }} --l1 ${{ matrix.L1 }} --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }} ${{ inputs.neureka-wmem && '--neureka-wmem' || '' }}
+
+          jq -c '.[]' tests.json | while read test; do
+            testName=$(echo "$test" | jq -r '.name')
+            L1_values=$(echo "$test" | jq -r '.L1[]')
+            for L1_value in $L1_values; do
+              echo "Running test: $testName with L1: $L1_value"
+              python testRunner_tiled_siracusa.py -t Tests/$testName --cores=${{ inputs.num-cores }} --l1 $L1_value --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }}
+            done
+          done
+
         shell: bash
         

--- a/.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
@@ -1,0 +1,61 @@
+name: TestRunnerTiledSiracusaWithNeureka
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+      num-cores:
+        required: false
+        default: 8
+        type: number
+      L1:
+        required: false
+        default: "[64000]"
+        type: string
+      default-memory-level:
+        required: false
+        default: "L2"
+        type: string
+      double-buffer:
+        required: false
+        default: false
+        type: boolean
+      neureka-wmem:
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+
+  test-runner-siracusa-tiled:
+    strategy:
+      fail-fast: false
+      matrix:
+        L1: ${{ fromJSON(inputs.L1) }}
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/victor-jung/deeploy:main
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Cache ccache
+        id: ccache-cache
+        uses: actions/cache@v4
+        with:
+          path: /app/.ccache
+          key: ${{ runner.os }}-ccache
+      - name: Run Test
+        run: |
+          cd DeeployTest
+          mkdir -p /app/.ccache
+          export CCACHE_DIR=/app/.ccache
+          source /app/install/pulp-sdk/configs/siracusa.sh
+          python testRunner_tiled_siracusa_w_neureka.py -t Tests/${{ inputs.test-name }} --cores=${{ inputs.num-cores }} --l1 ${{ matrix.L1 }} --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }} ${{ inputs.neureka-wmem && '--neureka-wmem' || '' }}
+        shell: bash
+        

--- a/.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
@@ -1,19 +1,15 @@
-name: TestRunnerTiledSiracusaWithNeureka
+name: TestRunnerTiledSiracusaWithNeurekaSequential
 
 on:
   workflow_call:
     inputs:
-      test-name:
+      tests-config:
         required: true
         type: string
       num-cores:
         required: false
         default: 8
         type: number
-      L1:
-        required: false
-        default: "[64000]"
-        type: string
       default-memory-level:
         required: false
         default: "L2"
@@ -30,10 +26,6 @@ on:
 jobs:
 
   test-runner-siracusa-neureka-tiled:
-    strategy:
-      fail-fast: false
-      matrix:
-        L1: ${{ fromJSON(inputs.L1) }}
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/victor-jung/deeploy:main
@@ -44,18 +36,30 @@ jobs:
           submodules: recursive
       - name: Build Deeploy
         run: pip install -e .
+      - name: Install jq
+        run: apt-get install -y jq
       - name: Cache ccache
-        id: ccache-cache-neureka
+        id: ccache-cache
         uses: actions/cache@v4
         with:
           path: /app/.ccache
-          key: ${{ runner.os }}-ccache-neureka
-      - name: Run Test
+          key: ${{ runner.os }}-ccache
+      - name: Run Tests
         run: |
           cd DeeployTest
+          echo '${{ inputs.tests-config }}' > tests.json
           mkdir -p /app/.ccache
           export CCACHE_DIR=/app/.ccache
           source /app/install/pulp-sdk/configs/siracusa.sh
-          python testRunner_tiled_siracusa_w_neureka.py -t Tests/${{ inputs.test-name }} --cores=${{ inputs.num-cores }} --l1 ${{ matrix.L1 }} --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }} ${{ inputs.neureka-wmem && '--neureka-wmem' || '' }}
+
+          jq -c '.[]' tests.json | while read test; do
+            testName=$(echo "$test" | jq -r '.name')
+            L1_values=$(echo "$test" | jq -r '.L1[]')
+            for L1_value in $L1_values; do
+              echo "Running test: $testName with L1: $L1_value"
+              python testRunner_tiled_siracusa_w_neureka.py -t Tests/$testName --cores=${{ inputs.num-cores }} --l1 $L1_value --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }} ${{ inputs.neureka-wmem && '--neureka-wmem' || '' }}
+            done
+          done
+
         shell: bash
         

--- a/Container/Dockerfile
+++ b/Container/Dockerfile
@@ -1,0 +1,119 @@
+########## Stage 1: Large image to build toolchains and emulator ##########
+FROM ubuntu:22.04 AS builder
+
+ARG PYTHON_VERSION=3.8.0
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+WORKDIR /app
+COPY toolchain/ toolchain/
+COPY Makefile ./
+
+RUN apt-get upgrade
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git-lfs \
+    cmake \
+    build-essential \
+    ccache \
+    ninja-build \
+    pkg-config \
+    ibglib2.0-dev \
+    libpixman-1-dev \
+    python3 \
+    python-is-python3 \
+    curl \
+    protobuf-compiler \
+    libftdi-dev \
+    libftdi1 \
+    doxygen \
+    libsdl2-dev \
+    scons \
+    gtkwave \
+    libsndfile1-dev \
+    rsync \
+    autoconf \
+    automake \
+    texinfo \
+    libtool \
+    libsdl2-ttf-dev \
+    gcc-multilib \
+    wget
+
+# Install Python
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+RUN tar xzf Python-${PYTHON_VERSION}.tgz
+RUN cd Python-${PYTHON_VERSION} && \
+    ./configure --enable-optimizations --prefix=/opt/python/ && \
+    make install -j
+
+# Install pip
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py
+
+# Build Rust tools
+RUN apt remove cargo -y
+RUN apt autoremove -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup install 1.63.0
+RUN rustup default 1.63.0
+RUN rustup component add rust-src
+
+# Compile toolchains
+RUN pip install meson
+RUN make llvm
+RUN make llvm-compiler-rt-riscv
+RUN make llvm-compiler-rt-arm
+RUN make picolibc-arm
+RUN make picolibc-riscv
+
+# # Compile emulators
+RUN make pulp-sdk
+RUN make qemu
+RUN make mempool
+RUN make banshee
+
+# Remove toolchain to make the container lighter
+RUN rm -rf toolchain
+
+
+########## Stage 2: Lightweight image with precompiled toolchain and emulators ##########
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# Export symbols necessary for Deeploy's build flow 
+ENV CMAKE=/usr/bin/cmake
+ENV PULP_SDK_HOME=/app/install/pulp-sdk
+ENV LLVM_INSTALL_DIR=/app/install/llvm
+ENV MEMPOOL_HOME=/app/install/mempool
+ENV PATH=/app/install/qemu/bin:/app/install/banshee:$PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+
+# Install dependencies
+RUN mkdir -p /root/.cargo/bin/ && \ 
+apt-get update && \ 
+DEBIAN_FRONTEND=noninteractive apt-get install -y git-lfs \
+cmake \
+ccache \ 
+curl \
+libpixman-1-dev \
+libsdl2-dev \
+python-is-python3 && \
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+python get-pip.py && \
+rm get-pip.py && \
+pip install nvidia-pyindex && \
+pip install toml-to-requirements && \
+toml-to-req --toml-file pyproject.toml && \
+pip install -r requirements.txt
+
+# Copy pre-built toolchains and emulators
+COPY --from=builder /app/install ./install
+COPY --from=builder /root/.cargo/bin/banshee /root/.cargo/bin/banshee

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ echo-bash:
 	@echo "export MEMPOOL_HOME=${MEMPOOL_INSTALL_DIR}"
 	@echo "export CMAKE=$$(which cmake)"
 	@echo "export PATH=${QEMU_INSTALL_DIR}/bin:${BANSHEE_INSTALL_DIR}:\$$PATH"
-	@echo "export PATH=~/.cargo/bin:$PATH"
+	@echo "export PATH=~/.cargo/bin:\$$PATH"
 	@echo "source ${PULP_SDK_INSTALL_DIR}/configs/siracusa.sh"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 'isort==5.12.0',
 'autoflake==2.3.0',
 "ortools",
-"onnx-graphsurgeon",
+'onnx-graphsurgeon==0.3.20',
 "sphinx>=7.0.0",
 "sphinx-rtd-theme>=1.3.0",
 "myst_parser",

--- a/toolchain/banshee.patch
+++ b/toolchain/banshee.patch
@@ -1,13 +1,15 @@
-// Copyright 2024 ETH Zurich and University of Bologna.
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
-//
-// Moritz Scherer <scheremo@iis.ee.ethz.ch>
 diff --git a/Cargo.toml b/Cargo.toml
-index d406357..7bd0f91 100644
+index d406357..23bcfcd 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -21,7 +21,7 @@ csv = "1.0.0-beta.2"
+@@ -15,13 +15,14 @@ anyhow = "1"
+ binread = "2.2.0"
+ bytebuffer = "0.2.1"
+ byteorder = "1.4.3"
++unicode-width = "=0.1.13"
+ clap = "2"
+ crossbeam-utils = "0.8"
+ csv = "1.0.0-beta.2"
  elf = "0.0.10"
  flexfloat = { path = "flexfloat" }
  itertools = "0.9"
@@ -35,23 +37,10 @@ index 216996b..e5abe38 100644
 --- a/src/engine.rs
 +++ b/src/engine.rs
 @@ -281,7 +281,6 @@ impl Engine {
-
+ 
              LLVMPassManagerBuilderPopulateFunctionPassManager(builder, func_passes);
              LLVMAddAnalysisPasses(tm, module_passes);
 -            LLVMPassManagerBuilderPopulateLTOPassManager(builder, module_passes, 0, 1);
              LLVMPassManagerBuilderPopulateModulePassManager(builder, module_passes);
-
+ 
              // Create and run the function pass manager.
-diff --git a/src/tran.rs b/src/tran.rs
-index 866b9d9..83ea9ff 100644
---- a/src/tran.rs
-+++ b/src/tran.rs
-@@ -20,7 +20,7 @@ use std::{
- };
- extern crate flexfloat;
-
--static NONAME: &'static i8 = unsafe { std::mem::transmute("\0".as_ptr()) };
-+static NONAME: &'static u8 = unsafe { std::mem::transmute("\0".as_ptr()) };
-
- /// Base address of the stream semantic regsiters
- static SSR_BASE: u64 = 0x204800;


### PR DESCRIPTION
# Changelog
This PR adds a GitHub-based Continuous Integration and Deployment to Deeploy. With this flow, we propagate a Docker container carrying Deeploy's dependencies. This allows new users to simply pull the Docker container and run Deeploy out-of-the-box. Moreover, the CI tests are run into this container.

On a personal GitHub account, one has access to 40 concurrent jobs, and the runtime of the CI is 14min. On the organization repo, we have only 20 concurrent jobs, so the runtime is 29min.

## Added
- `CI.yml` workflow containing the CI tests.
- `BuildDocker.yml` workflow that builds and pushes to GHCR the docker containing Deeploy's dependencies. 

## Changed
- Moved the GitLab CI flow from `main.yml` to `GitLabCI.yml`.

## Fixed
- Fixed a typo in the `Makefile`.
- Fixed the version of `onnx-graphsurgeon` to `0.3.20`, using the latest version results in errors for the `ICCT_ITA_8` ONNX graph.
- Fixed the `banshee.patch` by freezing the version of `unicode-width` to `0.1.13`. Since a few days, the default version is `0.1.14`, while it was `0.1.13` earlier. The version `0.1.14` is working only for Rust version above or equal to `1.66`.
