### PR TITLE
[build] Add script for Deeploy environment variables and Makefile info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ echo-bash:
 	@echo "export PATH=${QEMU_INSTALL_DIR}/bin:${BANSHEE_INSTALL_DIR}:\$$PATH"
 	@echo "export PATH=~/.cargo/bin:$PATH"
 	@echo "source ${PULP_SDK_INSTALL_DIR}/configs/siracusa.sh"
+	@echo ""
+	@echo "Or source the following script:"
+	@echo "source deeploy.sh"
 
 
 toolchain: llvm llvm-compiler-rt-riscv llvm-compiler-rt-arm picolibc-arm picolibc-riscv

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ echo-bash:
 	@echo "TL/DR: add these lines to run ~/.bashrc"
 	@echo "export PULP_SDK_HOME=${PULP_SDK_INSTALL_DIR}"
 	@echo "export LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR}"
-	@echo "export PULP_RISCV_GCC_TOOLCHAIN=/PULP_SDK_IS_A_MESS"
+	@echo "export PULP_RISCV_GCC_TOOLCHAIN="
 	@echo "export MEMPOOL_HOME=${MEMPOOL_INSTALL_DIR}"
 	@echo "export CMAKE=$$(which cmake)"
 	@echo "export PATH=${QEMU_INSTALL_DIR}/bin:${BANSHEE_INSTALL_DIR}:\$$PATH"
 	@echo "export PATH=~/.cargo/bin:$PATH"
 	@echo "source ${PULP_SDK_INSTALL_DIR}/configs/siracusa.sh"
 	@echo ""
-	@echo "Or source the following script:"
+	@echo "Or export the DEEPLOY_INSTALL_DIR variable and source the following script:"
 	@echo "source deeploy.sh"
 
 

--- a/deeploy.sh
+++ b/deeploy.sh
@@ -1,8 +1,8 @@
-export PULP_SDK_HOME=/scratch2/vivianep/Deeploy/install/pulp-sdk
-export LLVM_INSTALL_DIR=/scratch2/vivianep/Deeploy/install/llvm
-export PULP_RISCV_GCC_TOOLCHAIN=/PULP_SDK_IS_A_MESS
-export MEMPOOL_HOME=/scratch2/vivianep/Deeploy/install/mempool
+export PULP_SDK_HOME=${DEEPLOY_INSTALL_DIR}/pulp-sdk
+export LLVM_INSTALL_DIR=${DEEPLOY_INSTALL_DIR}/llvm
+export PULP_RISCV_GCC_TOOLCHAIN=
+export MEMPOOL_HOME=${DEEPLOY_INSTALL_DIR}/mempool
 export CMAKE=/usr/bin/cmake
-export PATH=/scratch2/vivianep/Deeploy/install/qemu/bin:/scratch2/vivianep/Deeploy/install/banshee:$PATH
+export PATH=${DEEPLOY_INSTALL_DIR}/qemu/bin:${DEEPLOY_INSTALL_DIR}/banshee:$PATH
 export PATH=~/.cargo/bin:$PATH
 source ${PULP_SDK_HOME}/configs/siracusa.sh

--- a/deeploy.sh
+++ b/deeploy.sh
@@ -1,0 +1,8 @@
+export PULP_SDK_HOME=/scratch2/vivianep/Deeploy/install/pulp-sdk
+export LLVM_INSTALL_DIR=/scratch2/vivianep/Deeploy/install/llvm
+export PULP_RISCV_GCC_TOOLCHAIN=/PULP_SDK_IS_A_MESS
+export MEMPOOL_HOME=/scratch2/vivianep/Deeploy/install/mempool
+export CMAKE=/usr/bin/cmake
+export PATH=/scratch2/vivianep/Deeploy/install/qemu/bin:/scratch2/vivianep/Deeploy/install/banshee:$PATH
+export PATH=~/.cargo/bin:$PATH
+source ${PULP_SDK_HOME}/configs/siracusa.sh


### PR DESCRIPTION
This PR introduces a new script (`deeploy.sh`) that sets up essential environment variables for the Deeploy project. The `Makefile` has been updated to reference this script, providing users an easy way to source environment variables directly from `deeploy.sh` after setting up the PULP SDK.

Changes:

1. Added `deeploy.sh` script for defining paths to critical tools (LLVM, PULP SDK, QEMU, etc.)
2. Updated `Makefile` to include instructions on sourcing the `deeploy.sh` script for proper environment configuration

This update simplifies the setup process by centralizing environment variables, reducing the need for manual configuration.