### PR TITLE
Fix shell for sequential tests of Generic, Cortex, and Mempool platforms

### DIFF
--- a/.github/workflows/TestRunnerCortexM.yml
+++ b/.github/workflows/TestRunnerCortexM.yml
@@ -29,4 +29,5 @@ jobs:
               python testRunner_cortexm.py -t Tests/$testName
             fi
           done
+        shell: bash
           

--- a/.github/workflows/TestRunnerGeneric.yml
+++ b/.github/workflows/TestRunnerGeneric.yml
@@ -29,4 +29,5 @@ jobs:
               python testRunner_generic.py -t Tests/$testName
             fi
           done
+        shell: bash
           

--- a/.github/workflows/TestRunnerMempool.yml
+++ b/.github/workflows/TestRunnerMempool.yml
@@ -29,4 +29,5 @@ jobs:
               python testRunner_mempool.py -t Tests/$testName
             fi
           done
+        shell: bash
           

--- a/.github/workflows/TestRunnerTiledSiracusaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaSequential.yml
@@ -56,6 +56,5 @@ jobs:
               python testRunner_tiled_siracusa.py -t Tests/$testName --cores=${{ inputs.num-cores }} --l1 $L1_value --defaultMemLevel=${{ inputs.default-memory-level }} ${{ inputs.double-buffer && '--doublebuffer' || '' }}
             done
           done
-
         shell: bash
         


### PR DESCRIPTION
The shell wasn't configured correctly for the Generic, CortexM, and Mempool platform tests. The tests were not executed, and the workflow didn't fail.