### PR TITLE
Add pre-commit for python formatting

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,3 +2,4 @@
 line_length=120
 multi_line_output=2
 include_trailing_comma=false
+skip=TargetLibraries/CMSIS/third_party, TargetLibraries/PULPOpen/third_party, install, toolchain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+exclude: .*third_party.*
+
+# By default, all hooks will be installed as pre-push
+default_stages: [pre-push]
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: check-added-large-files
+-   repo: https://github.com/PyCQA/autoflake
+    rev: v2.3.0
+    hooks:
+    -   id: autoflake
+        args:
+            - "--remove-all-unused-imports"
+            - "--ignore-init-module-imports"
+            - "--in-place"
+-   repo: https://github.com/google/yapf
+    rev: v0.33.0
+    hooks:
+    -   id: yapf
+        args:
+            - "--in-place"
+            - "--parallel"
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+        name: isort (python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,25 @@ Note that third party applications should not be formatted. You can alternativel
 make format
 ```
 to format all C and Python files.
+
+### Pre-commit
+
+Additionally, we provide the [pre-commit](https://pre-commit.com) configuration file which you can use to install github hooks that execute the formatting commands on your changes.
+
+You will need to manually install pre-commit since it's not added as a dependency to the `pyproject.toml`:
+```bash
+pip install pre-commit
+```
+
+The configuration sets the default stage for all the hooks to `pre-push` so to install the git hooks run:
+```bash
+pre-commit install --hook-type pre-push
+```
+The hooks will run before each push, making sure the pushed code can pass linting checks and not fail the CI on linting.
+
+If you change your mind and don't want the git hooks:
+```bash
+pre-commit uninstall
+```
+
+_Note:_ This configures only the python formatting git hooks. The c formatting is not supported at the moment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,18 +19,18 @@ Deeploy mainly consists of code implemented in C, Makefile, and Python. To facil
 
 To recursively format all Python files run:
 ```bash
-$>	autoflake -i -r --remove-all-unused-imports --ignore-init-module-imports --exclude "*/third_party/**" ./
-$>	yapf -ipr -e "third_party/" -e "install/" -e "toolchain/" ./
-$>	isort --sg "**/third_party/*"  --sg "install/*" --sg "toolchain/*" ./
+autoflake -i -r --remove-all-unused-imports --ignore-init-module-imports --exclude "*/third_party/**" .
+yapf -ipr .
+isort .
 ```
 
 And for C files:
 ```bash
-$> python scripts/run_clang_format.py -e "*/third_party/*" -e "*/install/*" -e "*/toolchain/*" -ir --clang-format-executable=${LLVM_INSTALL_DIR}/bin/clang-format ./
+python scripts/run_clang_format.py -e "*/third_party/*" -e "*/install/*" -e "*/toolchain/*" -ir --clang-format-executable=${LLVM_INSTALL_DIR}/bin/clang-format ./
 ```
 
 Note that third party applications should not be formatted. You can alternatively also run:
-```
+```bash
 make format
 ```
 to format all C and Python files.


### PR DESCRIPTION
Add pre-commit config for the python formatting.
Pre-commit makes it easy to add git hooks that check your changes before either committing, pushing, or merging them.
I set the default stage for this config to be `pre-push` so that it isn't too overbearing.

I didn't add the clang-format because pre-commit doesn't support environment variables and I didn't think of any other clever way to overcome that. We could hardcode the path to the standard llvm installation path (`install/llvm`) but I don't like that.

I removed the `$> ` from CONTRIBUTING.md so that you can c/p the commands directly to terminal.