### PR TITLE
Fix main.c Float Cast Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,10 @@
 - Float bug on Testslice, CMSIS TestUtil, DivInterger
 - AbstractDatayType Float Bugs
 
+## Fix main.c Float Cast Bugs
+
+### Added
+- Add one new #define OUTPUTTYPE to testoutput.h
+
+### Changed
+Change main.c to use OUTPUTTYPE instead of float

--- a/DeeployTest/Platforms/Generic/main.c
+++ b/DeeployTest/Platforms/Generic/main.c
@@ -50,22 +50,37 @@ int main() {
 
   int32_t tot_err = 0;
   uint32_t tot = 0;
-  float32_t diff;
-  float32_t expected, actual;
+  OUTPUTTYPE diff;
+  OUTPUTTYPE expected, actual;
+
   for (uint32_t buf = 0; buf < DeeployNetwork_num_outputs; buf++) {
-    tot += DeeployNetwork_outputs_bytes[buf] / sizeof(float32_t);
-    for (uint32_t i = 0;
-         i < DeeployNetwork_outputs_bytes[buf] / sizeof(float32_t); i++) {
-      expected = ((float32_t *)testOutputVector[buf])[i];
-      actual = ((float32_t *)DeeployNetwork_outputs[buf])[i];
+    tot += DeeployNetwork_outputs_bytes[buf] / sizeof(OUTPUTTYPE);
+    for (uint32_t i = 0; i < DeeployNetwork_outputs_bytes[buf] / sizeof(OUTPUTTYPE); i++) {
+      expected = ((OUTPUTTYPE *)testOutputVector[buf])[i];
+      actual = ((OUTPUTTYPE *)DeeployNetwork_outputs[buf])[i];
       diff = expected - actual;
 
-      if ((diff < 0 ? -diff : diff) > 1e-5) {
+#if OUTPUTTYPE == float32_t
+      // Allow margin of error for float32_t
+      if ((diff < -1e-4) || (diff > 1e-4))
+      {
         tot_err += 1;
-        printf("Expected: %10.6f  ", expected);
-        printf("Actual: %10.6f  ", actual);
-        printf("Diff: %10.6f at Index %12u in Output %u\r\n", diff, i, buf);
+        printf("Expected: %10.6f  ", (float)expected);
+        printf("Actual: %10.6f  ", (float)actual);
+        printf("Diff: %10.6f at Index %12u in Output %u\r\n", (float)diff, i, buf);
       }
+#elif OUTPUTTYPE == int32_t
+      // No margin for integer comparison
+      if (diff != 0)
+      {
+        tot_err += 1;
+        printf("Expected: %4d  ", expected);
+        printf("Actual: %4d  ", actual);
+        printf("Diff: %4d at Index %12u in Output %u\r\n", diff, i, buf);
+      }
+#else
+#error "Unsupported OUTPUTTYPE"
+#endif
     }
   }
 

--- a/DeeployTest/Platforms/Generic/main.c
+++ b/DeeployTest/Platforms/Generic/main.c
@@ -61,7 +61,7 @@ int main() {
       diff = expected - actual;
 
 #if OUTPUTTYPE == float32_t
-      // Allow margin of error for float32_t
+      // RUNWANG: Allow margin of error for float32_t
       if ((diff < -1e-4) || (diff > 1e-4))
       {
         tot_err += 1;
@@ -70,7 +70,7 @@ int main() {
         printf("Diff: %10.6f at Index %12u in Output %u\r\n", (float)diff, i, buf);
       }
 #elif OUTPUTTYPE == int32_t
-      // No margin for integer comparison
+      // RUNWANG: No margin for integer comparison
       if (diff != 0)
       {
         tot_err += 1;

--- a/DeeployTest/testUtils/codeGenerate.py
+++ b/DeeployTest/testUtils/codeGenerate.py
@@ -125,6 +125,7 @@ def generateTestOutputsHeader(deployer: NetworkDeployer,
 
         data_type = output_data_type[f"output_{index}"]
         data_width = data_type.referencedType.typeWidth
+        retStr += f"#define OUTPUTTYPE {data_type.referencedType.typeName}\n"
         retStr += f"{data_type.referencedType.typeName} testOutputVector{index}[] ="
         retStr += "{"
 

--- a/DeeployTest/testUtils/codeGenerate.py
+++ b/DeeployTest/testUtils/codeGenerate.py
@@ -125,7 +125,12 @@ def generateTestOutputsHeader(deployer: NetworkDeployer,
 
         data_type = output_data_type[f"output_{index}"]
         data_width = data_type.referencedType.typeWidth
+        isdatafloat = (data_type.referencedType.typeName == "float32_t")
         retStr += f"#define OUTPUTTYPE {data_type.referencedType.typeName}\n"
+        if isdatafloat:
+            retStr += f"#define ISOUTPUTFLOAT 1\n"
+        else:
+            retStr += f"#define ISOUTPUTFLOAT 0\n"
         retStr += f"{data_type.referencedType.typeName} testOutputVector{index}[] ="
         retStr += "{"
 


### PR DESCRIPTION
Fix main.c Float Cast Bugs

## Added
 Add one new #define OUTPUTTYPE to testoutput.h

## Changed
-  Change main.c to use OUTPUTTYPE instead of float

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated. 
