### PR TITLE
Infinite Lifetime Buffers Considered in Tiling & Memory Allocation (+ Visualization)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,10 @@ jobs:
   
   ### Generic Tests ###
   generic-kernels:
-    needs: select-docker-image
     uses: ./.github/workflows/TestRunnerGeneric.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         Adder
         MultIO

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,13 +19,13 @@ jobs:
       image: ${{ steps.docker-image.outputs.image }}
     steps:
       - id: docker-image
-        run: echo "::set-output name=image::${{ env.IMAGE }}"
+        run: echo "::set-output name=image::${{ env.DOCKER_IMAGE }}"
 
   build-deeploy:
     runs-on: ubuntu-22.04
     needs: select-docker-image
     container:
-      image: ${{ needs.docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 1 */6 * *"
 
 env:
-  DOCKER_IMAGE: ghcr.io/victor-jung/deeploy:main
+  DOCKER_IMAGE: ghcr.io/pulp-platform/deeploy:main
 
 jobs:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,9 @@ jobs:
 
   generic-models:
     uses: ./.github/workflows/TestRunnerGeneric.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         simpleRegression
         WaveFormer

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -676,10 +676,10 @@ jobs:
       - name: Run Test
         run: |
           cd DeeployTest
-          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=40000 --memAllocStrategy=MiniMalloc
-          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=30000 --memAllocStrategy=MiniMalloc --shouldFail
-          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=80000 --memAllocStrategy=TetrisRandom
-          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=40000 --memAllocStrategy=TetrisRandom --shouldFail
+          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=75000 --memAllocStrategy=MiniMalloc
+          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=70000 --memAllocStrategy=MiniMalloc --shouldFail
+          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=90000 --memAllocStrategy=TetrisRandom
+          python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=75000 --memAllocStrategy=TetrisRandom --shouldFail
 
   deeploy-state-serialization:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,7 @@ jobs:
   
   ### Generic Tests ###
   generic-kernels:
+    needs: select-docker-image
     uses: ./.github/workflows/TestRunnerGeneric.yml
     with:
       test-names: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,12 +8,24 @@ on:
     # Runs the CI on the default branch every 6 days at 2AM CET to keep the cache fresh
     - cron: "0 1 */6 * *"
 
+env:
+  DOCKER_IMAGE: ghcr.io/victor-jung/deeploy:main
+
 jobs:
+
+  select-docker-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-image.outputs.image }}
+    steps:
+      - id: docker-image
+        run: echo "::set-output name=image::${{ env.IMAGE }}"
 
   build-deeploy:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,7 +96,9 @@ jobs:
   ### CortexM Tests ###
   cortexm-kernels: 
     uses: ./.github/workflows/TestRunnerCortexM.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         Adder
         MultIO
@@ -112,7 +114,9 @@ jobs:
 
   cortexm-models: 
     uses: ./.github/workflows/TestRunnerCortexM.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         simpleRegression
         WaveFormer 
@@ -120,7 +124,9 @@ jobs:
   ### Snitch Tests ###
   snitch-kernels:
     uses: ./.github/workflows/TestRunnerSnitch.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         Adder
         iSoftmax
@@ -139,7 +145,9 @@ jobs:
 
   snitch-kernels-tiled-singlebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSnitchSequential.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       tests-config: |
         [
           {
@@ -185,7 +193,9 @@ jobs:
   ### Mempool Tests ###
   mempool-kernels:
     uses: ./.github/workflows/TestRunnerMempool.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
           Adder
           MultIO
@@ -210,7 +220,9 @@ jobs:
 
   mempool-models:
     uses: ./.github/workflows/TestRunnerMempool.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         simpleRegression
         simpleCNN
@@ -225,7 +237,9 @@ jobs:
   ### Siracusa Tests ###
   siracusa-kernels:
     uses: ./.github/workflows/TestRunnerSiracusa.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         Adder
         MultIO
@@ -256,7 +270,9 @@ jobs:
 
   siracusa-models:
     uses: ./.github/workflows/TestRunnerSiracusa.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-names: |
         simpleRegression
         miniMobileNet
@@ -270,7 +286,9 @@ jobs:
 
   siracusa-kernels-tiled-singlebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaSequential.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       tests-config: |
         [
           {
@@ -346,7 +364,9 @@ jobs:
 
   siracusa-kernels-tiled-doublebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaSequential.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       tests-config: |
         [
           {
@@ -451,7 +471,9 @@ jobs:
         num-cores:
           - 8
     uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -480,7 +502,9 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -516,7 +540,9 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -525,7 +551,9 @@ jobs:
 
   siracusa-neureka-kernels-tiled-singlebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       tests-config: |
         [
           {
@@ -549,7 +577,9 @@ jobs:
 
   siracusa-neureka-kernels-tiled-doublebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       tests-config: |
         [
           {
@@ -590,7 +620,9 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -614,7 +646,9 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -623,7 +657,9 @@ jobs:
 
   siracusa-neureka-kernels-tiled-singlebuffer-L2-wmem:
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       tests-config: |
         [
           {
@@ -668,7 +704,9 @@ jobs:
         neureka-wmem:
           - true
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+    needs: select-docker-image
     with:
+      docker-image: ${{ needs.select-docker-image.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -680,8 +718,9 @@ jobs:
   ### Deeploy Extension and Internal Tests ###
   deeploy-memory-allocation:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -699,8 +738,9 @@ jobs:
 
   deeploy-state-serialization:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -719,8 +759,9 @@ jobs:
 
   deeploy-memory-level-extension:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -739,8 +780,9 @@ jobs:
 
   deeploy-tiler-extension:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -763,8 +805,9 @@ jobs:
 
   deeploy-memory-allocation-extension:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -785,8 +828,9 @@ jobs:
 
   deeploy-typing:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -802,8 +846,9 @@ jobs:
 
   deeploy-regex-matching:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -819,8 +864,9 @@ jobs:
 
   linting:
     runs-on: ubuntu-22.04
+    needs: select-docker-image
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ needs.select-docker-image.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerCortexM.yml
+++ b/.github/workflows/TestRunnerCortexM.yml
@@ -3,6 +3,9 @@ name: TestRunnerCortexM
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-names:
         required: true
         type: string
@@ -11,7 +14,7 @@ jobs:
   test-runner-cortexm:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerGeneric.yml
+++ b/.github/workflows/TestRunnerGeneric.yml
@@ -3,6 +3,9 @@ name: TestRunnerGeneric
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-names:
         required: true
         type: string
@@ -11,7 +14,7 @@ jobs:
   test-runner-generic:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerMempool.yml
+++ b/.github/workflows/TestRunnerMempool.yml
@@ -3,6 +3,9 @@ name: TestRunnerMempool
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-names:
         required: true
         type: string
@@ -11,7 +14,7 @@ jobs:
   test-runner-mempool:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerSiracusa.yml
+++ b/.github/workflows/TestRunnerSiracusa.yml
@@ -3,6 +3,9 @@ name: TestRunnerSiracusa
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-names:
         required: true
         type: string
@@ -14,7 +17,7 @@ jobs:
   test-runner-siracusa:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerSnitch.yml
+++ b/.github/workflows/TestRunnerSnitch.yml
@@ -3,6 +3,9 @@ name: TestRunnerSnitch
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-names:
         required: true
         type: string
@@ -17,7 +20,7 @@ jobs:
   test-runner-snitch:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerTiledSiracusa.yml
+++ b/.github/workflows/TestRunnerTiledSiracusa.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusa
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-name:
         required: true
         type: string
@@ -40,7 +43,7 @@ jobs:
         L1: ${{ fromJSON(inputs.L1) }}
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerTiledSiracusaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaSequential.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusaSequential
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       tests-config:
         required: true
         type: string
@@ -32,7 +35,7 @@ jobs:
   test-runner-siracusa-tiled:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusaWithNeureka
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       test-name:
         required: true
         type: string
@@ -45,7 +48,7 @@ jobs:
         L1: ${{ fromJSON(inputs.L1) }}
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusaWithNeurekaSequential
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       tests-config:
         required: true
         type: string
@@ -36,7 +39,7 @@ jobs:
   test-runner-siracusa-neureka-tiled:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerTiledSnitchSequential.yml
+++ b/.github/workflows/TestRunnerTiledSnitchSequential.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSnitchSequential
 on:
   workflow_call:
     inputs:
+      docker-image:
+        required: true
+        type: string
       tests-config:
         required: true
         type: string
@@ -32,7 +35,7 @@ jobs:
   test-runner-snitch-tiled:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/deeploy:main
+      image: ${{ inputs.docker-image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/Deeploy/TilingExtension/MemoryScheduler.py
+++ b/Deeploy/TilingExtension/MemoryScheduler.py
@@ -33,6 +33,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 import numpy as np
 from ortools.constraint_solver.pywrapcp import IntVar
 
+from Deeploy.DeeployTypes import VariableBuffer
 from Deeploy.CommonExtensions.OptimizationPasses.TopologyOptimizationPasses.LoweringOptimizationPasses import \
     _permuteList
 from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, TransientBuffer
@@ -428,6 +429,15 @@ class MemoryScheduler():
 
         return tensorLifetimeMap
 
+    def getConstantTensorOffset(self, ctxt: NetworkContext, memoryLevel: str):
+        constantTensorSize = 0
+        for buffer in ctxt.globalObjects.values():
+            # JUNGVI: TODO: Once I/O have finite lifetime we can just check for ConstantBuffer here
+            if not "MEMORYARENA" in buffer.name and isinstance(buffer, VariableBuffer) and buffer._memoryLevel == memoryLevel:
+                constantTensorSize += np.prod(buffer.shape) * buffer._type.referencedType.typeWidth // 8
+
+        return int(constantTensorSize)
+
     def _scheduleMemoryConstraints(self,
                                    tilerModel: TilerModel,
                                    ctxt: NetworkContext,
@@ -492,8 +502,10 @@ class MemoryScheduler():
 
             self._permutationState[memoryLevel + f"_{patternIdx}"] = permutationMatrix
 
+            constantTensorOffset = self.getConstantTensorOffset(ctxt, memoryLevel)
+
             cost = self._generateCost(tilerModel, permAdj, permCost, patternIdx)
-            constr = cost < memoryHierarchy.memoryLevels[memoryLevel].size
+            constr = (cost + constantTensorOffset) < memoryHierarchy.memoryLevels[memoryLevel].size
             tilerModel.addConstraint(constr)
 
         return
@@ -510,8 +522,7 @@ class MemoryScheduler():
         return self._scheduleMemoryConstraints(tilerModel, ctxt, allMemoryConstraints, memoryHierarchy,
                                                memoryAllocStrategy, memoryLevel)
 
-    @staticmethod
-    def constraintTileBuffersWithOverlappingLifetime(tilerModel: TilerModel, ctxt: NetworkContext,
+    def constraintTileBuffersWithOverlappingLifetime(self, tilerModel: TilerModel, ctxt: NetworkContext,
                                                      patternMemoryConstraint: PatternMemoryConstraints,
                                                      memoryHierarchy: MemoryHierarchy):
         """JUNGVI: This method adds the necessay constraints for tiling to be performed before the static memory allocation of the tile buffers.
@@ -543,11 +554,12 @@ class MemoryScheduler():
 
             for memoryLevel in memoryHierarchy.memoryLevels.values():
                 sumExpr = 0
+                constantTensorOffset = self.getConstantTensorOffset(ctxt, memoryLevel.name)
                 for infoDict in tileMemoryConstraint.values():
                     if memoryLevel.name == infoDict['memoryLevel']:
                         sumExpr += infoDict['sizeVar'] * infoDict['typeWidthFactor'] * infoDict['multiBufferCoeff']
                 if sumExpr != 0:
-                    tilerModel.addConstraint(sumExpr <= memoryLevel.size)
+                    tilerModel.addConstraint(sumExpr + constantTensorOffset <= memoryLevel.size)
 
     def getSymbolicCostName(self, patternIdx: int, memoryLevel: str) -> str:
         stringSuffix = self._stringSuffix + f"_{memoryLevel}"

--- a/Deeploy/TilingExtension/MemoryScheduler.py
+++ b/Deeploy/TilingExtension/MemoryScheduler.py
@@ -33,10 +33,9 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 import numpy as np
 from ortools.constraint_solver.pywrapcp import IntVar
 
-from Deeploy.DeeployTypes import VariableBuffer
 from Deeploy.CommonExtensions.OptimizationPasses.TopologyOptimizationPasses.LoweringOptimizationPasses import \
     _permuteList
-from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, TransientBuffer
+from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, TransientBuffer, VariableBuffer
 from Deeploy.MemoryLevelExtension.MemoryLevels import MemoryHierarchy
 from Deeploy.TilingExtension.MemoryConstraints import PatternMemoryConstraints, TensorMemoryConstraint
 from Deeploy.TilingExtension.TilerModel import TilerModel
@@ -433,7 +432,8 @@ class MemoryScheduler():
         constantTensorSize = 0
         for buffer in ctxt.globalObjects.values():
             # JUNGVI: TODO: Once I/O have finite lifetime we can just check for ConstantBuffer here
-            if not "MEMORYARENA" in buffer.name and isinstance(buffer, VariableBuffer) and buffer._memoryLevel == memoryLevel:
+            if not "MEMORYARENA" in buffer.name and isinstance(buffer,
+                                                               VariableBuffer) and buffer._memoryLevel == memoryLevel:
                 constantTensorSize += np.prod(buffer.shape) * buffer._type.referencedType.typeWidth // 8
 
         return int(constantTensorSize)

--- a/Deeploy/TilingExtension/TilerExtension.py
+++ b/Deeploy/TilingExtension/TilerExtension.py
@@ -32,7 +32,7 @@ import copy
 import csv
 import os
 import subprocess
-from typing import Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Dict, List, Literal, Optional, Tuple, Type, Union, OrderedDict
 
 import numpy as np
 import onnx_graphsurgeon as gs
@@ -364,7 +364,7 @@ class Tiler():
 
         return tilingSchedule, memoryMap
 
-    def setupModel(self, ctxt: NetworkContext, schedule: Schedule, layerBinding: 'OrderedDict[str, ONNXLayer]',
+    def setupModel(self, ctxt: NetworkContext, schedule: Schedule, layerBinding: OrderedDict[str, ONNXLayer],
                    targetMemoryLevelMapping: TargetMemoryLevelMapping) -> NetworkContext:
 
         wrapSchedule: List[SubGraph] = []
@@ -497,7 +497,7 @@ class Tiler():
 
         for idx, pattern in enumerate(schedule):
             subGraph = gs.Graph(nodes = pattern)
-            subgraphTensors: 'OrderedDict[str, gs.Tensor]' = subGraph.tensors(check_duplicates = True)
+            subgraphTensors: OrderedDict[str, gs.Tensor] = subGraph.tensors(check_duplicates = True)
 
             for _, tensor in subgraphTensors.items():
                 if not ctxt.lookup(tensor.name)._deploy:
@@ -508,7 +508,7 @@ class Tiler():
         return tilerModel
 
     def _setupGeometricConstraints(self, tilerModel: TilerModel, ctxt: NetworkContext, schedule: List[SubGraph],
-                                   layerBinding: 'OrderedDict[str, ONNXLayer]') -> TilerModel:
+                                   layerBinding: OrderedDict[str, ONNXLayer]) -> TilerModel:
 
         # SCHEREMO: Each pattern is a decoupled sub-problem w.r.t the geometric constraints.
         # We need to regenerate dimension variables for each tensor
@@ -571,7 +571,7 @@ class Tiler():
 
     def _setupMemoryConstraints(
             self, tilerModel: TilerModel, ctxt: NetworkContext, schedule: List[SubGraph],
-            layerBinding: 'OrderedDict[str, ONNXLayer]',
+            layerBinding: OrderedDict[str, ONNXLayer],
             targetMemoryLevelMapping: TargetMemoryLevelMapping) -> Tuple[TilerModel, List[PatternMemoryConstraints]]:
 
         allMemoryConstraints = self._generateAllMemoryConstraints(tilerModel, ctxt, schedule, layerBinding,
@@ -611,7 +611,7 @@ class Tiler():
 
     def _generateAllMemoryConstraints(
             self, tilerModel: TilerModel, ctxt: NetworkContext, schedule: List[SubGraph],
-            layerBinding: 'OrderedDict[str, ONNXLayer]',
+            layerBinding: OrderedDict[str, ONNXLayer],
             targetMemoryLevelMapping: TargetMemoryLevelMapping) -> List[PatternMemoryConstraints]:
 
         dynamicTensorConstraints, constantTensorConstraints = self._generateMemoryConstraints(
@@ -631,7 +631,7 @@ class Tiler():
 
     def _generateMemoryConstraints(
         self, tilerModel: TilerModel, ctxt: NetworkContext, schedule: List[SubGraph],
-        layerBinding: 'OrderedDict[str, ONNXLayer]', targetMemoryLevelMapping: TargetMemoryLevelMapping
+        layerBinding: OrderedDict[str, ONNXLayer], targetMemoryLevelMapping: TargetMemoryLevelMapping
     ) -> Tuple[List[PatternMemoryConstraints], NodeMemoryConstraint]:
 
         # SCHEREMO: Construct non-double-buffered constraints of local variable buffers
@@ -796,7 +796,7 @@ class Tiler():
 
     def _generateVariableBufferConstraints(
         self, tilerModel: TilerModel, ctxt: NetworkContext, schedule: List[SubGraph],
-        layerBinding: 'OrderedDict[str, ONNXLayer]', targetMemoryLevelMapping: TargetMemoryLevelMapping
+        layerBinding: OrderedDict[str, ONNXLayer], targetMemoryLevelMapping: TargetMemoryLevelMapping
     ) -> Tuple[List[PatternMemoryConstraints], List[PatternMemoryConstraints]]:
 
         def deltaFlow(
@@ -868,7 +868,7 @@ class Tiler():
         return outerMemConstraints, innerMemConstraints
 
     def _generatePatternStepTransientBufferConstraints(
-            self, tilerModel: TilerModel, ctxt: NetworkContext, layerBinding: 'OrderedDict[str, ONNXLayer]',
+            self, tilerModel: TilerModel, ctxt: NetworkContext, layerBinding: OrderedDict[str, ONNXLayer],
             step: gs.Node, targetMemoryLevelMapping: TargetMemoryLevelMapping) -> NodeMemoryConstraint:
 
         patternStepTransientBufferSizes = NodeMemoryConstraint()

--- a/Deeploy/TilingExtension/TilerExtension.py
+++ b/Deeploy/TilingExtension/TilerExtension.py
@@ -120,7 +120,7 @@ class Tiler():
         constantBuffersOffset = 0
         for ioBuffers in infiniteLifetimeBuffers:
             _ioSize = np.prod(ioBuffers.shape) * ioBuffers._type.referencedType.typeWidth // 8
-            _maxLifetime = len(memoryMap[defaultMemoryLevel.name][-1])
+            _maxLifetime = len(memoryMap[defaultMemoryLevel.name])
             fig.add_trace(
                 go.Scatter(x = [
                     -0.5, -0.5, _maxLifetime + 0.5, _maxLifetime + 0.5
@@ -326,16 +326,17 @@ class Tiler():
 
         if self.memoryAllocStrategy == "MiniMalloc":
             for memoryLevel in memoryMap.keys():
+                constantTensorOffset = self.outerMemoryScheduler.getConstantTensorOffset(ctxt, memoryLevel)
                 if memoryLevel == self.memoryHierarchy._defaultMemoryLevel.name:
                     memoryMap[memoryLevel][-1] = self.minimalloc(memoryMap[memoryLevel][-1], ctxt, None,
-                                                                 self.memoryHierarchy.memoryLevels[memoryLevel].size,
+                                                                 self.memoryHierarchy.memoryLevels[memoryLevel].size - constantTensorOffset,
                                                                  memoryLevel)
                 else:
                     for idx, memMap in enumerate(memoryMap[memoryLevel]):
                         if len(memoryMap[memoryLevel][idx]) != 0:
                             memoryMap[memoryLevel][idx] = self.minimalloc(
                                 memMap, ctxt, tilingSchedule[idx].nodeConstraints[0],
-                                self.memoryHierarchy.memoryLevels[memoryLevel].size, memoryLevel)
+                                self.memoryHierarchy.memoryLevels[memoryLevel].size - constantTensorOffset, memoryLevel)
             print(f"\033[92mMemory allocation sucessful!\033[0m")
 
         for idx, pattern in enumerate(tilingSchedule):

--- a/DeeployTest/testMVP.py
+++ b/DeeployTest/testMVP.py
@@ -250,7 +250,7 @@ if __name__ == '__main__':
                         help = 'Adds EXPERIMENTAL support for strided convolutions on N-EUREKA\n')
     parser.add_argument('--doublebuffer', action = 'store_true')
     parser.add_argument('--l1', metavar = 'l1', dest = 'l1', type = int, default = 64000, help = 'Set L1 size\n')
-    parser.add_argument('--l2', metavar = 'l2', dest = 'l2', type = int, default = 512000, help = 'Set L2 size\n')
+    parser.add_argument('--l2', metavar = 'l2', dest = 'l2', type = int, default = 1024000, help = 'Set L2 size\n')
     parser.add_argument('--shouldFail', action = 'store_true')
     parser.add_argument('--overwriteRecentState',
                         action = 'store_true',

--- a/DeeployTest/testUtils/testRunner.py
+++ b/DeeployTest/testUtils/testRunner.py
@@ -198,7 +198,7 @@ class TestRunnerArgumentParser(argparse.ArgumentParser):
                               metavar = '<size>',
                               dest = 'l2',
                               type = int,
-                              default = 512000,
+                              default = 1024000,
                               help = 'Set L2 size\n')
             self.add_argument('--randomizedMemoryScheduler',
                               action = "store_true",


### PR DESCRIPTION
~~This PR is based on [this](https://github.com/pulp-platform/Deeploy/pull/40) currently open PR, don't review it before [PR#36](https://github.com/pulp-platform/Deeploy/pull/40) is merged.~~

This PR modified the tiling and memory allocation stage of Deeploy to take into account the memory space taken by constant buffers.

## Added
- The `getConstantTensorOffset` method in the `MemoryScheduler` to have the size in Bytes of the Weights and IO Tensors. SPOILER: In the next PR adding finite lifetime to IO, I will align this method to only count `ConstantBuffer.`
- Add the offset caused by constant tensors to the memory scheduler, both when using Tetris memory alloc and MiniMalloc.
- I also added the constant buffers to the memory allocation visualization.

## Changed
- Since we take into account the constants (Weights and IO) in Tiling and Memory Alloc, I increased the default L2 memory of Siracusa to pass all tests. The same thing goes for the `deploy-memory-alloc` tests.

## Fixed
- Some type hints were forward references; this is unnecessary, so I made them standard type hints.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [ ] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
