### PR TITLE
HOTFIX: Find all subdirectories of Deeploy when installing with pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,3 +308,6 @@ Change main.c to use OUTPUTTYPE instead of float
 ### Changed
 - The ISA for the Siracusa platform has been updated from rv32imc_zfinx_xpulpv2 to rv32imf_xpulpv2.
 - All floating-point comparison tasks in deeploytest.c are now offloaded to Cluster 0 for execution.
+
+## Small changes
+- HOTFIX: Deeploy subdirectories installed when installing Deeploy with pip install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,6 @@ dependencies = [
 "ninja",
 "plotly"
 ]
-[tool.setuptools]
-packages = ['Deeploy']
+[tool.setuptools.packages.find]
+include = ["Deeploy*"]
+exclude = ["DeeployTest*"]


### PR DESCRIPTION
I tried installing Deeploy like so:
```
pip install git+https://github.com/lukamac/Deeploy.git@devel --extra-index-url=https://pypi.ngc.nvidia.com
```
but the only files that got installed are:
```
Deeploy
├── AbstractDataTypes.py
├── DeeployTypes.py
├── __init__.py
```
All the subdirectories are missing. I believe that's not what was intended.

## Fixed
- pip install now installs all the subdirectories

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [ ] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
