### PR TITLE
Fix TEST_RECENT linking on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,7 @@ Change main.c to use OUTPUTTYPE instead of float
 
 ## Small changes
 - HOTFIX: Deeploy subdirectories installed when installing Deeploy with pip install
+- HOTFIX: Linking TEST_RECENT on MacOS
 
 
 ## Add RV32IMF Picolibc support for Siracusa platform

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -20,8 +20,8 @@ macro(link_compile_dump name)
         POST_BUILD
         COMMAND
             mkdir -p ${CMAKE_SOURCE_DIR}/DeeployTest/TEST_RECENT &&
-            ln -sf -T ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/DeeployTest/TEST_RECENT/build &&
-            ln -sf -T ${GENERATED_SOURCE} ${CMAKE_SOURCE_DIR}/DeeployTest/TEST_RECENT/src
+            ln -sfn ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/DeeployTest/TEST_RECENT/build &&
+            ln -sfn ${GENERATED_SOURCE} ${CMAKE_SOURCE_DIR}/DeeployTest/TEST_RECENT/src
             )
 endmacro()
 


### PR DESCRIPTION
The `-T` option is GNU-specific and not supported by MacOS. The `-n` option is supported by both Linux and MacOS and achieves the same effect that if the symbolic link to a directory already exists, it overwrites it with a different source.

Tested on mac and linux.

## Fixed
- linking TEST_RECENT on MacOS

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
