### PR TITLE
HOT: Autoselect Self-Hosted Runners if the Action is on Upstream 

### DIFF
--- a/.github/workflows/BuildDocker.yml
+++ b/.github/workflows/BuildDocker.yml
@@ -9,7 +9,7 @@ jobs:
   build-docker:
     permissions: write-all
     name: Deploy Docker image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # Free up disk space on Github-hosted runner
       - name: Disk usage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,19 +13,27 @@ env:
 
 jobs:
 
-  select-docker-image:
+  select-docker-image-and-runner:
     runs-on: ubuntu-latest
     outputs:
-      image: ${{ steps.docker-image.outputs.image }}
+      image: ${{ steps.set-docker-image.outputs.image }}
+      runner: ${{ steps.set-runner.outputs.runner }}
     steps:
-      - id: docker-image
+      - id: set-docker-image
         run: echo "::set-output name=image::${{ env.DOCKER_IMAGE }}"
+      - id: set-runner
+        run: |
+          if [[ "${{ github.repository }}" == "pulp-platform/Deeploy" ]]; then
+            echo "::set-output name=runner::self-hosted"
+          else
+            echo "::set-output name=runner::ubuntu-latest"
+          fi
 
   build-deeploy:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -38,9 +46,10 @@ jobs:
   ### Generic Tests ###
   generic-kernels:
     uses: ./.github/workflows/TestRunnerGeneric.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         Adder
         MultIO
@@ -80,9 +89,10 @@ jobs:
 
   generic-models:
     uses: ./.github/workflows/TestRunnerGeneric.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         simpleRegression
         WaveFormer
@@ -99,9 +109,10 @@ jobs:
   ### CortexM Tests ###
   cortexm-kernels:
     uses: ./.github/workflows/TestRunnerCortexM.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         Adder
         MultIO
@@ -117,9 +128,10 @@ jobs:
 
   cortexm-models:
     uses: ./.github/workflows/TestRunnerCortexM.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         simpleRegression
         WaveFormer
@@ -127,9 +139,10 @@ jobs:
   ### Snitch Tests ###
   snitch-kernels:
     uses: ./.github/workflows/TestRunnerSnitch.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         Adder
         iSoftmax
@@ -147,9 +160,10 @@ jobs:
 
   snitch-kernels-tiled-singlebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSnitchSequential.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       tests-config: |
         [
           {
@@ -194,9 +208,10 @@ jobs:
   ### Mempool Tests ###
   mempool-kernels:
     uses: ./.github/workflows/TestRunnerMempool.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
           Adder
           MultIO
@@ -221,9 +236,10 @@ jobs:
 
   mempool-models:
     uses: ./.github/workflows/TestRunnerMempool.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         simpleRegression
         simpleCNN
@@ -238,9 +254,10 @@ jobs:
   ### Siracusa Tests ###
   siracusa-kernels:
     uses: ./.github/workflows/TestRunnerSiracusa.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         Adder
         MultIO
@@ -278,9 +295,10 @@ jobs:
 
   siracusa-models:
     uses: ./.github/workflows/TestRunnerSiracusa.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-names: |
         simpleRegression
         miniMobileNet
@@ -295,9 +313,10 @@ jobs:
 
   siracusa-kernels-tiled-singlebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaSequential.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       tests-config: |
         [
           {
@@ -377,9 +396,10 @@ jobs:
 
   siracusa-kernels-tiled-doublebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaSequential.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       tests-config: |
         [
           {
@@ -486,9 +506,10 @@ jobs:
         num-cores:
           - 8
     uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -525,9 +546,10 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -572,9 +594,10 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusa.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -583,9 +606,10 @@ jobs:
 
   siracusa-neureka-kernels-tiled-singlebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       tests-config: |
         [
           {
@@ -609,9 +633,10 @@ jobs:
 
   siracusa-neureka-kernels-tiled-doublebuffer-L2:
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       tests-config: |
         [
           {
@@ -652,15 +677,15 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
       default-memory-level: ${{ matrix.default-memory-level }}
 
-  # TEMPORARILY DISABLE L3 TRANSFER DUE TO DRIVER BUG CAUSING SPORADIC CRASH
   siracusa-neureka-models-tiled-doublebuffer-L3:
     strategy:
       fail-fast: false
@@ -679,9 +704,10 @@ jobs:
         default-memory-level:
           - "L3"
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -690,9 +716,10 @@ jobs:
 
   siracusa-neureka-kernels-tiled-singlebuffer-L2-wmem:
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       tests-config: |
         [
           {
@@ -715,7 +742,6 @@ jobs:
       num-cores: 8
       neureka-wmem: true
 
-  # TEMPORARILY DISABLE L3 TRANSFER DUE TO DRIVER BUG CAUSING SPORADIC CRASH
   siracusa-neureka-models-tiled-doublebuffer-L3-wmem:
     strategy:
       fail-fast: false
@@ -738,9 +764,10 @@ jobs:
         neureka-wmem:
           - true
     uses: ./.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
-    needs: select-docker-image
+    needs: select-docker-image-and-runner
     with:
-      docker-image: ${{ needs.select-docker-image.outputs.image }}
+      runner: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+      docker-image: ${{ needs.select-docker-image-and-runner.outputs.image }}
       test-name: ${{ matrix.test-data.name }}
       num-cores: ${{ matrix.num-cores }}
       L1: ${{ toJson(matrix.test-data.L1) }}
@@ -751,10 +778,10 @@ jobs:
 
   ### Deeploy Extension and Internal Tests ###
   deeploy-memory-allocation:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -771,10 +798,10 @@ jobs:
           python testMVP.py -t Tests/CCT/CCT_1_16_16_8 -p Siracusa  --defaultMemLevel=L2 --l1=64000 --l2=75000 --memAllocStrategy=TetrisRandom --shouldFail
 
   deeploy-state-serialization:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -792,10 +819,10 @@ jobs:
         shell: bash
 
   deeploy-memory-level-extension:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -813,10 +840,10 @@ jobs:
         shell: bash
 
   deeploy-tiler-extension:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -838,10 +865,10 @@ jobs:
         shell: bash
 
   deeploy-memory-allocation-extension:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -861,10 +888,10 @@ jobs:
         shell: bash
 
   deeploy-typing:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -879,10 +906,10 @@ jobs:
         shell: bash
 
   deeploy-debug:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -899,10 +926,10 @@ jobs:
         shell: bash
 
   deeploy-regex-matching:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -917,10 +944,10 @@ jobs:
         shell: bash
 
   linting:
-    runs-on: ubuntu-22.04
-    needs: select-docker-image
+    runs-on: ${{ needs.select-docker-image-and-runner.outputs.runner }}
+    needs: select-docker-image-and-runner
     container:
-      image: ${{ needs.select-docker-image.outputs.image }}
+      image: ${{ needs.select-docker-image-and-runner.outputs.image }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/TestRunnerCortexM.yml
+++ b/.github/workflows/TestRunnerCortexM.yml
@@ -3,6 +3,9 @@ name: TestRunnerCortexM
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -12,7 +15,7 @@ on:
 
 jobs:
   test-runner-cortexm:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerGeneric.yml
+++ b/.github/workflows/TestRunnerGeneric.yml
@@ -3,6 +3,9 @@ name: TestRunnerGeneric
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -12,7 +15,7 @@ on:
 
 jobs:
   test-runner-generic:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerMempool.yml
+++ b/.github/workflows/TestRunnerMempool.yml
@@ -3,6 +3,9 @@ name: TestRunnerMempool
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -12,7 +15,7 @@ on:
 
 jobs:
   test-runner-mempool:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerSiracusa.yml
+++ b/.github/workflows/TestRunnerSiracusa.yml
@@ -3,6 +3,9 @@ name: TestRunnerSiracusa
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -15,7 +18,7 @@ on:
 
 jobs:
   test-runner-siracusa:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerSnitch.yml
+++ b/.github/workflows/TestRunnerSnitch.yml
@@ -3,6 +3,9 @@ name: TestRunnerSnitch
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -18,7 +21,7 @@ on:
 
 jobs:
   test-runner-snitch:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerTiledSiracusa.yml
+++ b/.github/workflows/TestRunnerTiledSiracusa.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusa
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -41,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         L1: ${{ fromJSON(inputs.L1) }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerTiledSiracusaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaSequential.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusaSequential
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -33,7 +36,7 @@ on:
 jobs:
 
   test-runner-siracusa-tiled:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaWithNeureka.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusaWithNeureka
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -46,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         L1: ${{ fromJSON(inputs.L1) }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
+++ b/.github/workflows/TestRunnerTiledSiracusaWithNeurekaSequential.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSiracusaWithNeurekaSequential
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -37,7 +40,7 @@ on:
 jobs:
 
   test-runner-siracusa-neureka-tiled:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/.github/workflows/TestRunnerTiledSnitchSequential.yml
+++ b/.github/workflows/TestRunnerTiledSnitchSequential.yml
@@ -3,6 +3,9 @@ name: TestRunnerTiledSnitchSequential
 on:
   workflow_call:
     inputs:
+      runner:
+        required: true
+        type: string
       docker-image:
         required: true
         type: string
@@ -33,7 +36,7 @@ on:
 jobs:
 
   test-runner-snitch-tiled:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## Autoselect Self-Hosted Runners if the Action runs on Upstream
+
+### Changed
+- Adapt the select docker image stage to also select a runner depending on ` github.repository`
+- Adapt the jobs and reusable workflows to use the selected runner.
+
+
 ## Improve Documentation and VSCode Support
 
 ### Added


### PR DESCRIPTION
Deeploy now has it's own self-hosted runners to avoid hogging PULP Platform's shared actions. However, these self-hoster runners should be used only when running actions on the PULP-Platform, not on forks. This PR adds the necessary logic to select the runner depending on the repo the action is running.

## Changed
- Adapt the select docker image stage to also select a runner depending on ` github.repository`
- Adapt the jobs and reusable workflows to use the selected runner.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
