### PR TITLE
Cache Build Artefacts

### DIFF
--- a/.github/workflows/GenerateCCache.yml
+++ b/.github/workflows/GenerateCCache.yml
@@ -16,7 +16,7 @@ jobs:
     generate-ccache:
       runs-on: ubuntu-latest
       container:
-        image:  ${{ github.event.inputs.docker_image_deeploy }}
+        image:  ${{ github.event.inputs.docker_image_deeploy || 'ghcr.io/pulp-platform/deeploy:devel' }}
       steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/GenerateCCache.yml
+++ b/.github/workflows/GenerateCCache.yml
@@ -1,0 +1,45 @@
+name: GenerateCCache
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_image_deeploy:
+        description: 'Deeploy Image to use'
+        required: false
+        default: 'ghcr.io/pulp-platform/deeploy:devel'
+  schedule:
+    # Runs the workflow on the default branch every 6 days at 2AM CET to keep the cache fresh
+    - cron: "0 1 */6 * *"
+
+jobs:
+
+    generate-ccache:
+      runs-on: ubuntu-latest
+      container:
+        image:  ${{ github.event.inputs.docker_image_deeploy }}
+      steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Deeploy
+        run: pip install -e .
+      - name: Generate CCache
+        run: |
+          cd DeeployTest
+          mkdir -p /app/.ccache
+          export CCACHE_DIR=/app/.ccache
+          python testRunner_generic.py -t ./Tests/Adder
+          python testRunner_mempool.py  -t ./Tests/Adder
+          python testRunner_cortexm.py  -t ./Tests/Adder
+          python testRunner_snitch.py  -t ./Tests/Adder
+          python testRunner_siracusa.py  -t ./Tests/Adder
+          python testRunner_tiled_siracusa.py  -t ./Tests/Adder
+          python testRunner_tiled_siracusa_w_neureka.py  -t ./Tests/Adder
+      - name: Clean and Upload CCache
+        uses: actions/cache@v4
+        with:
+          path: /app/.ccache
+          key: ccache-ci
+
+    

--- a/.github/workflows/GenerateCCache.yml
+++ b/.github/workflows/GenerateCCache.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: 'ghcr.io/pulp-platform/deeploy:devel'
   schedule:
-    # Runs the workflow on the default branch every 6 days at 2AM CET to keep the cache fresh
-    - cron: "0 1 */6 * *"
+    # Runs the workflow on the default branch every day at 1AM CET to keep the cache fresh
+    - cron: "0 1 * * *"
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 This release containing major architectural changes, new platform support, enhanced simulation workflows, floating-point kernel support, training infrastructure for CCT models, memory allocation strategies, and documentation improvements.
 
 ### List of Pull Requests
+- Cache Build Artefacts [#82](https://github.com/pulp-platform/Deeploy/pull/82)
 - Fix Linting in CI and Reformat C Files [#86](https://github.com/pulp-platform/Deeploy/pull/86)
 - Fix Broken CMake Flow For pulp-sdk [#87](https://github.com/pulp-platform/Deeploy/pull/87)
 - Refactor Changelog For Release [#85](https://github.com/pulp-platform/Deeploy/pull/85)
@@ -57,6 +58,9 @@ This release containing major architectural changes, new platform support, enhan
 - Port GitLab CI [#1](https://github.com/pulp-platform/Deeploy/pull/1)
 
 ### Added
+- Generate CCcache action
+- Concurrency group by branch name
+- Define a default container on main branch
 - Tutorial section in the documentation
 - Guide on using the debug print topology pass and code transformation
 - VSCode configuration files for improved IDE support
@@ -169,6 +173,7 @@ This release containing major architectural changes, new platform support, enhan
 - Add helper script to generate a baseline changelog.
 
 ### Changed
+- CI tests use ccache in a read-only manner
 - Adapt the select docker image stage to also select a runner depending on ` github.repository`
 - Adapt the jobs and reusable workflows to use the selected runner.
 - Updated `README.md` description to use a persistent development container


### PR DESCRIPTION
This PR adds a proper mechanism to cache the build artifacts from each platform in Deeploy and reuse them in the CI. The `GenerateCCache.yml` (to trigger manually) action generates and caches the ccache. Then the CI uses this cache (as read-only) to speedup the build.

Additionally, this PR introduces a concurrency group per branch name for the CI action. This concurrency group automatically cancels old actions in this group; hence, if you push two commits to the same branch, only the latest commit will run the CI. 

Finally, this PR set `ghcr.io/pulp-platform/deeploy:devel'` as the default container, except if we are on the main branch, in which case the container is `ghcr.io/pulp-platform/deeploy:devel'`

With GitHub-hosted runners: 
- Before: 15m 28s
- Now: 8m 43s

The impact on self-hosted runners will be greater as they are more bottlenecked by the compilation stage.

## Added
- Add `GenerateCCache.yml` action to generate the CI ccache.
- Add `ghcr.io/pulp-platform/deeploy:devel'` as the default container for the CI, except if we are on the main branch, in which case the container is `ghcr.io/pulp-platform/deeploy:devel'`.
- Add a concurrency group by branch name to cancel outdated CI runs.

## Changed
- The CI tests use the CI ccache as a read-only cache.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
