### PR TITLE
HOTFIX: Fix Broken CMake Flow For pulp-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 This release containing major architectural changes, new platform support, enhanced simulation workflows, floating-point kernel support, training infrastructure for CCT models, memory allocation strategies, and documentation improvements.
 
 ### List of Pull Requests
+- Fix Broken CMake Flow For pulp-sdk [#87](https://github.com/pulp-platform/Deeploy/pull/87)
 - Refactor Changelog For Release [#85](https://github.com/pulp-platform/Deeploy/pull/85)
 - ARM Docker Container and Minor Bug Fix [#84](https://github.com/pulp-platform/Deeploy/pull/84)
 - Added Kernel for Generic Float DW Conv2D [#63](https://github.com/pulp-platform/Deeploy/pull/63)
@@ -234,6 +235,7 @@ This release containing major architectural changes, new platform support, enhan
 - Fixed broken VSCode launch configuration
 - Fixed broken `pulp-sdk` hash
 - Fix issue with building `banshee` on `linux/arm
+- Removed `i3c` related files from the `pulp-sdk` CMake flow
 
 ### Removed
 - Remove the link to the precompiled LLVM 12 in the `testRunner` for Snitch and in the CI.

--- a/TargetLibraries/PULPOpen/cmake/pulp-sdk-siracusa.cmake
+++ b/TargetLibraries/PULPOpen/cmake/pulp-sdk-siracusa.cmake
@@ -22,11 +22,6 @@ set(SIRACUSA_INCLUDES
 set(PULP_SDK_SIRACUSA_C_SOURCE
   ${PULP_SDK_HOME}/rtos/pulpos/pulp/kernel/chips/siracusa/pll.c
   ${PULP_SDK_HOME}/rtos/pulpos/pulp/kernel/chips/siracusa/soc.c
-  ${PULP_SDK_HOME}/rtos/pulpos/pulp/drivers/i3c/src/cdn_print.c
-  ${PULP_SDK_HOME}/rtos/pulpos/pulp/drivers/i3c/src/command_list.c
-  #${PULP_SDK_HOME}/rtos/pulpos/pulp/drivers/i3c/src/i3c.c
-  ${PULP_SDK_HOME}/rtos/pulpos/pulp/drivers/i3c/src/i3c_obj_if.c
-  ${PULP_SDK_HOME}/rtos/pulpos/pulp/drivers/i3c/src/cps_impl.c
   ${PULP_SDK_HOME}/rtos/pulpos/pulp/drivers/siracusa_padmux/src/siracusa_padctrl.c
 )
 


### PR DESCRIPTION
This PR fixes the broken CMake flow for the `pulp-sdk` as the i3c files were removed from the repo. The reason the CI is still passing is because we use the `deeploy:main` container with the old `pulp-sdk`.

## Fixed
-  Removed `i3c` related files from the `pulp-sdk` CMake flow

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [ ] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
