### PR TITLE
Add Luka as Code Owner

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,12 +22,12 @@ jobs:
           sphinx-build docs _build
       - name: Prepare Multipages
         uses: rkdarst/gh-pages-multibranch@main
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           directory: _build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
-          pip install numpy mako onnx_graphsurgeon ortools sphinx sphinx_rtd_theme myst-parser[linkify] sphinx_favicon
+          pip install . --extra-index-url=https://pypi.ngc.nvidia.com
+          pip install -r requirements-dev.txt
       - name: Sphinx build
         run: |
           sphinx-build docs _build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 This release containing major architectural changes, new platform support, enhanced simulation workflows, floating-point kernel support, training infrastructure for CCT models, memory allocation strategies, and documentation improvements.
 
 ### List of Pull Requests
+- Add Luka as Code Owner [#101](https://github.com/pulp-platform/Deeploy/pull/101)
 - Fix CI, Docker Files, and Documentation Workflow [#100](https://github.com/pulp-platform/Deeploy/pull/100)
 - Chimera Platform Integration [#96](https://github.com/pulp-platform/Deeploy/pull/96)
 - Add Tutorial and Refactor README [#97](https://github.com/pulp-platform/Deeploy/pull/97)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @victor-jung @xeratec
+*       @victor-jung @xeratec @lukamac


### PR DESCRIPTION
This PR adds @lukamac as a code owner for the Deeploy project and enables to trigger the documentation deployment manually. Additionally, it changes the documentation workflow to install the required dependencies according to `project.toml` and `requirements-dev.txt`.

- Working CI workflow: https://github.com/Xeratec/Deeploy/actions/runs/16028351803
- Working manual deployment of documentation: https://github.com/Xeratec/Deeploy/actions/runs/16028659822

## Added
- Add @lukamac as code owner

## Changed
- Enable deployment of GitHub Pages documentation manually
- Adapt the documentation workflow to install dependencies according to `project.toml` and `requirements-dev.txt`

## Problem Overview
### Problem 1: Sphinx Import Warnings
The Spinx documentation generates many warnings during the build process, due to missing dependencies. This potnetially leads to incomplete documentation or missing features in the generated documentation.

```
Possible hints:
* ImportError: 
* ModuleNotFoundError: No module named 'plotly'
* AttributeError: module 'Deeploy.Targets.Snitch' has no attribute 'Platform'
WARNING: [autosummary] failed to import Deeploy.Targets.Snitch.Tiler.
```

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
