### PR TITLE
Prepare v0.2.0 Release

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "image": "ghcr.io/pulp-platform/deeploy:main",
+    "name": "deeploy_main",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack",
+                "twxs.cmake",
+                "josetr.cmake-language-support-vscode",
+                "ms-vscode.cmake-tools",
+                "ms-python.python",
+                "ms-vscode-remote.remote-containers",
+                "rioj7.command-variable"
+            ]
+        }
+    },
+    "mounts": [
+        {
+            "source": "${localWorkspaceFolder}",
+            "target": "/app/Deeploy",
+            "type": "bind"
+        }
+    ]
+}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
   pull_request:
   workflow_dispatch:
     inputs:
@@ -14,11 +18,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  DOCKER_IMAGE: ${{ github.event.inputs.docker_image_deeploy || (github.ref_name == 'main' && 'ghcr.io/pulp-platform/deeploy:main' || 'ghcr.io/pulp-platform/deeploy:devel') }}
-
 jobs:
-
   select-docker-image-and-runner:
     runs-on: ubuntu-latest
     outputs:
@@ -26,13 +26,28 @@ jobs:
       runner: ${{ steps.set-runner.outputs.runner }}
     steps:
       - id: set-docker-image
-        run: echo "::set-output name=image::${{ env.DOCKER_IMAGE }}"
+        run: |
+          if [[ -n "${{ github.event.inputs.docker_image_deeploy }}" ]]; then
+            IMAGE="${{ github.event.inputs.docker_image_deeploy }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TAG_NAME="${GITHUB_REF##refs/tags/}"
+            IMAGE="ghcr.io/pulp-platform/deeploy:${TAG_NAME}"
+          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+            IMAGE="ghcr.io/pulp-platform/deeploy:main"
+          else
+            IMAGE="ghcr.io/pulp-platform/deeploy:devel"
+          fi
+          echo "Selected image: ${IMAGE}"
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+
       - id: set-runner
         run: |
           if [[ "${{ github.repository }}" == "pulp-platform/Deeploy" ]]; then
-            echo "::set-output name=runner::self-hosted"
+            echo "Selected self-hosted runner for Deeploy repository"
+            echo "runner=self-hosted" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=runner::ubuntu-latest"
+            echo "Selected ubuntu-latest runner for external repository"
+            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
           fi
 
   build-deeploy:
@@ -117,7 +132,7 @@ jobs:
         miniMobileNetv2
         CCT/CCT_1_16_16_8
         testFloatDemoTinyViT
-  
+
   ### SoftHier Tests ###
   softhier-kernels:
     uses: ./.github/workflows/TestRunnerSoftHier.yml
@@ -170,8 +185,8 @@ jobs:
         Adder
       simulators: |
         gvsoc
-  
-        
+
+
   ### Snitch Tests ###
   snitch-kernels:
     uses: ./.github/workflows/TestRunnerSnitch.yml

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           sphinx-build docs _build
       - name: Prepare Multipages
-        uses: rkdarst/gh-pages-multibranch@main
+        uses: xeratec/gh-pages-multibranch@pr/support_tags
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           directory: _build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -563,7 +563,7 @@ run_generic_test_kernels: # This job runs in the test stage.
   stage: test # It only starts when the job in the build stage completes successfully.
   parallel:
     matrix:
-    - TEST: [Adder, MultIO, test1DConvolution, test2DConvolution, test1DDWConvolution, test2DDWConvolution, test1DPad, test2DPad, testGEMM, testMatMul, testMatMulAdd, testMaxPool, testRQConv, testRQMatMul, testReduceSum, testReduceMean, testSlice, testRequantizedDWConv, test2DRequantizedConv, iSoftmax]
+    - TEST: [Adder, MultIO, test1DConvolution, test2DConvolution, test1DDWConvolution, test2DDWConvolution, test1DPad, test2DPad, testConcat, testGEMM, testMatMul, testMatMulAdd, testMaxPool, testRQConv, testRQMatMul, testReduceSum, testReduceMean, testSlice, testRequantizedDWConv, test2DRequantizedConv, iSoftmax]
   script:
     - !reference [.setup_test, script]
     - python testRunner_generic.py -t ./Tests/$TEST --toolchain=$TOOLCHAIN --toolchain_install_dir=$LLVM_INSTALL_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 This file contains the changelog for the Deeploy project. The changelog is divided into sections based on the version of the project. Each section contains a list of pull requests, features, changes, fixes, and removals that were made in that version.
 
-## Unreleased (Planned Release Target: v0.2.0)
+## Release v0.2.0 (2025-07-09)
 This release containing major architectural changes, new platform support, enhanced simulation workflows, floating-point kernel support, training infrastructure for CCT models, memory allocation strategies, and documentation improvements.
 
 ### List of Pull Requests
+- Prepare v0.2.0 release [#102](https://github.com/pulp-platform/Deeploy/pull/102)
 - Add Luka as Code Owner [#101](https://github.com/pulp-platform/Deeploy/pull/101)
 - Fix CI, Docker Files, and Documentation Workflow [#100](https://github.com/pulp-platform/Deeploy/pull/100)
 - Chimera Platform Integration [#96](https://github.com/pulp-platform/Deeploy/pull/96)

--- a/Deeploy/Targets/Generic/Platform.py
+++ b/Deeploy/Targets/Generic/Platform.py
@@ -30,22 +30,22 @@ from Deeploy.CommonExtensions.OptimizationPasses.TopologyOptimizationPasses.Lowe
     RemoveEmptyConvBiasPass
 from Deeploy.DeeployTypes import ConstantBuffer, DeploymentEngine, DeploymentPlatform, NodeMapper, NodeTemplate, \
     StructBuffer, TopologyOptimizer, TransientBuffer, VariableBuffer
-from Deeploy.Targets.Generic.Bindings import BasicAddBindings, BasicConv1DBinding, BasicConv2DBindings, \
-    BasicDebugPrintBindings, BasicDequantBindings, BasicDivBindings, BasicDWConv1DBinding, BasicDWConv2DBindings, \
-    BasicGatherBindings, BasicGELUBindings, BasicGEMMBindings, BasicITAPartialSoftmaxBinding, BasicITASoftmaxBinding, \
-    BasicLayerNormBindings, BasicMatMulBindings, BasicMaxPool2DBindings, BasicMulBindings, BasicPad1DBindings, \
-    BasicPad2DBindings, BasicQuantBindings, BasicReduceMeanBindings, BasicReduceSumBindings, BasicReluBinding, \
-    BasicReshapeBindings, BasicRQIntegerDivBinding, BasicRQSBindings, BasicRQSGELUBinding, BasicSliceBindings, \
-    BasicSoftmaxBindings, BasicTransposeBindings, DummyBinding
-from Deeploy.Targets.Generic.Layers import AddLayer, ConvLayer, DebugPrintLayer, DequantLayer, DivLayer, GatherLayer, \
-    GELULayer, GEMMLayer, ITAMaxLayer, LayerNormLayer, MatMulLayer, MaxPoolLayer, MulLayer, PadLayer, QuantLayer, \
-    ReduceMeanLayer, ReduceSumLayer, ReluLayer, RequantShiftLayer, ReshapeLayer, RQIntegerDivLayer, RQSiGELULayer, \
-    SliceLayer, SoftmaxLayer, TransposeLayer
-from Deeploy.Targets.Generic.Parsers import AddParser, DebugParser, DequantParser, DivParser, DummyParser, \
-    FlattenParser, GatherParser, GELUParser, GenericConv1DParser, GenericConv2DParser, GenericDWConv1DParser, \
-    GenericDWConv2DParser, GenericGEMMParser, GenericMaxPool2DParser, IntegerDivParser, ITAMaxParser, \
-    ITAPartialMaxParser, LayerNormParser, MatMulParser, MulParser, Pad1DParser, Pad2DParser, QuantParser, \
-    ReduceMeanParser, ReduceSumParser, ReluParser, RequantShiftParser, ReshapeParser, RQIntegerDivParser, \
+from Deeploy.Targets.Generic.Bindings import BasicAddBindings, BasicConcatBindings, BasicConv1DBinding, \
+    BasicConv2DBindings, BasicDebugPrintBindings, BasicDequantBindings, BasicDivBindings, BasicDWConv1DBinding, \
+    BasicDWConv2DBindings, BasicGatherBindings, BasicGELUBindings, BasicGEMMBindings, BasicITAPartialSoftmaxBinding, \
+    BasicITASoftmaxBinding, BasicLayerNormBindings, BasicMatMulBindings, BasicMaxPool2DBindings, BasicMulBindings, \
+    BasicPad1DBindings, BasicPad2DBindings, BasicQuantBindings, BasicReduceMeanBindings, BasicReduceSumBindings, \
+    BasicReluBinding, BasicReshapeBindings, BasicRQIntegerDivBinding, BasicRQSBindings, BasicRQSGELUBinding, \
+    BasicSliceBindings, BasicSoftmaxBindings, BasicTransposeBindings, DummyBinding
+from Deeploy.Targets.Generic.Layers import AddLayer, ConcatLayer, ConvLayer, DebugPrintLayer, DequantLayer, DivLayer, \
+    GatherLayer, GELULayer, GEMMLayer, ITAMaxLayer, LayerNormLayer, MatMulLayer, MaxPoolLayer, MulLayer, PadLayer, \
+    QuantLayer, ReduceMeanLayer, ReduceSumLayer, ReluLayer, RequantShiftLayer, ReshapeLayer, RQIntegerDivLayer, \
+    RQSiGELULayer, SliceLayer, SoftmaxLayer, TransposeLayer
+from Deeploy.Targets.Generic.Parsers import AddParser, ConcatParser, DebugParser, DequantParser, DivParser, \
+    DummyParser, FlattenParser, GatherParser, GELUParser, GenericConv1DParser, GenericConv2DParser, \
+    GenericDWConv1DParser, GenericDWConv2DParser, GenericGEMMParser, GenericMaxPool2DParser, IntegerDivParser, \
+    ITAMaxParser, ITAPartialMaxParser, LayerNormParser, MatMulParser, MulParser, Pad1DParser, Pad2DParser, \
+    QuantParser, ReduceMeanParser, ReduceSumParser, ReluParser, RequantShiftParser, ReshapeParser, RQIntegerDivParser, \
     RQSiGELUParser, SliceParser, SoftmaxParser, TransposeParser, UnsqueezeParser, iLayerNormParser, iSoftmaxParser
 from Deeploy.Targets.Generic.Templates import AllocateTemplate, FreeTemplate
 from Deeploy.Targets.Generic.TopologyOptimizationPasses.Passes import DequantPatternPass, ExtractPaddingFromConvPass, \
@@ -55,6 +55,7 @@ from Deeploy.Targets.Generic.TopologyOptimizationPasses.Passes import DequantPat
 AddMapper = NodeMapper(AddParser(), BasicAddBindings)
 Conv1DMapper = NodeMapper(GenericConv1DParser(), [BasicConv1DBinding])
 Conv2DMapper = NodeMapper(GenericConv2DParser(), BasicConv2DBindings)
+ConcatMapper = NodeMapper(ConcatParser(), BasicConcatBindings)
 DebugMapper = NodeMapper(DebugParser(), BasicDebugPrintBindings)
 DWConv1DMapper = NodeMapper(GenericDWConv1DParser(), [BasicDWConv1DBinding])
 DWConv2DMapper = NodeMapper(GenericDWConv2DParser(), BasicDWConv2DBindings)
@@ -96,6 +97,7 @@ DummyMapper = NodeMapper(DummyParser(), [DummyBinding])
 GenericMapping = {
     'Add': AddLayer([AddMapper]),
     'Conv': ConvLayer([Conv2DMapper, DWConv2DMapper, Conv1DMapper, DWConv1DMapper]),
+    'Concat': ConcatLayer([ConcatMapper]),
     'DebugPrint': DebugPrintLayer([DebugMapper]),
     'Div': DivLayer([DivMapper]),
     'Flatten': ReshapeLayer([FlattenMapper]),


### PR DESCRIPTION
This PR finalizes the preparation of the `v0.2.0` release. After merging this into `devel`, the release process will proceed with:

1. Opening a release PR from `devel` to `main`
2. Pushing a Git tag for the release after merging the release PR
3. Creating a GitHub release with the prepared tag.

This release flow has been tested successfully on a fork. Note: Since the release tag references the Docker container tagged with the release tag (`ghcr.io/pulp-platform/deeploy:v0.2.0`), the CI will initially fail.  The Deeploy Docker image must be built after the release PR is merged and the CI restarted.

Additionally, this PR adds a `.devcontainer.json` file to configure a development container for use with tools like VS Code Remote Development and GitHub Codespaces.

## Workflows
- CI Workflow (tag): https://github.com/Xeratec/Deeploy/actions/runs/16125960931
- CI Workflow (branch): https://github.com/Xeratec/Deeploy/actions/runs/16125540878
- Documentation (tag): https://xeratec.github.io/Deeploy/tag/v0.2.0/
- Documentation (branch): https://xeratec.github.io/Deeploy/branch/pr--v0.2.0/

## Added
- CI support for tag-based release builds
- Docker image resolution for tag-based workflows
- Concat operator support in the Generic platform
- Tag and branch handling in Sphinx docs
- Switch to a multi-branch GitHub page action supporting tags

## Changed
- CI runner logic updated for self-hosted/main vs external forks

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
4. [x] All checks are passing.
5. [x] The `CHANGELOG.md` file has been updated.
6. [x] If the docker was modified, change back its link after review.
