### PR TITLE
Use Docker digests instead of arch-specific tags

### DIFF
--- a/.github/workflows/BuildDockerDeeploy.yml
+++ b/.github/workflows/BuildDockerDeeploy.yml
@@ -57,17 +57,18 @@ jobs:
           haskell: true
           large-packages: true
 
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v3
 
       - name: GHCR Log-in
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Cache for Docker
-        uses: actions/cache@v3
+        id: cache
+        uses: actions/cache@v4
         with:
           path: var-ccache
           key: ${{ runner.os }}-${{ matrix.platform }}-build-cache-deeploy
@@ -108,7 +109,7 @@ jobs:
     needs: [ prepare, build-deeploy ]
     steps:
       - name: GHCR Log-in
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/BuildDockerDeeploy.yml
+++ b/.github/workflows/BuildDockerDeeploy.yml
@@ -36,6 +36,9 @@ jobs:
     name: Build Deploy Image
     needs: [ prepare ]
     runs-on: ${{ matrix.runner }}
+    outputs:
+      digest-amd64: ${{ steps.digest.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.digest.outputs.digest-arm64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,6 +92,7 @@ jobs:
           OWNER: '${{ github.repository_owner }}'
 
       - name: Build and push final deploy image
+        id: build
         uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.platform }}
@@ -99,9 +103,11 @@ jobs:
           push: true
           build-args: |
             BASE_IMAGE=${{ github.event.inputs.docker_image_toolchain }}
-          tags: |
-            ghcr.io/${{ env.OWNER_LC }}/deeploy:latest-${{ matrix.platform }}
-            ghcr.io/${{ env.OWNER_LC }}/deeploy:${{ needs.prepare.outputs.docker_tag }}-${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.OWNER_LC }}/deeploy,annotation-index=true,name-canonical=true,push=true
+
+      - name: Extract image digest
+        id: digest
+        run: echo "digest-${{ matrix.platform }}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   merge-deeploy-images:
     name: Merge Deeploy Images
@@ -121,8 +127,13 @@ jobs:
         env:
           OWNER: '${{ github.repository_owner }}'
 
-      - uses: Noelware/docker-manifest-action@v1
+      - name: Merge Deeploy Images
+        uses: Noelware/docker-manifest-action@v1
         with:
-          inputs: ghcr.io/${{ env.OWNER_LC }}/deeploy:latest-amd64,ghcr.io/${{ env.OWNER_LC }}/deeploy:latest-arm64
-          tags: ghcr.io/${{ env.OWNER_LC }}/deeploy:latest,ghcr.io/${{ env.OWNER_LC }}/deeploy:${{ needs.prepare.outputs.docker_tag }}
+          inputs: |
+            ghcr.io/${{ env.OWNER_LC }}/deeploy@${{ needs.build-deeploy.outputs.digest-amd64 }},
+            ghcr.io/${{ env.OWNER_LC }}/deeploy@${{ needs.build-deeploy.outputs.digest-arm64 }}
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/deeploy:latest,
+            ghcr.io/${{ env.OWNER_LC }}/deeploy:${{ needs.prepare.outputs.docker_tag }}
           push: true

--- a/.github/workflows/BuildDockerToolchain.yml
+++ b/.github/workflows/BuildDockerToolchain.yml
@@ -31,6 +31,9 @@ jobs:
     name: Build Deeploy Toolchain Image
     needs: [ prepare ]
     runs-on: ${{ matrix.runner }}
+    outputs:
+      digest-amd64: ${{ steps.digest.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.digest.outputs.digest-arm64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,15 +86,18 @@ jobs:
           OWNER: '${{ github.repository_owner }}'
 
       - name: Build and push toolchain image
+        id: build
         uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.platform }}
           context: .
           file: Container/Dockerfile.toolchain
           push: true
-          tags: |
-            ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:latest-${{ matrix.platform }}
-            ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:${{ needs.prepare.outputs.docker_tag }}-${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain,annotation-index=true,name-canonical=true,push=true
+
+      - name: Extract image digest
+        id: digest
+        run: echo "digest-${{ matrix.platform }}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   merge-toolchain-images:
     name: Merge Deeploy Toolchain Images
@@ -111,8 +117,13 @@ jobs:
         env:
           OWNER: '${{ github.repository_owner }}'
 
-      - uses: Noelware/docker-manifest-action@v1
+      - name: Merge Toolchain Images
+        uses: Noelware/docker-manifest-action@v1
         with:
-          inputs: ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:latest-amd64,ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:latest-arm64
-          tags: ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:latest,ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:${{ needs.prepare.outputs.docker_tag }}
+          inputs: |
+            ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain@${{ needs.build-toolchain.outputs.digest-amd64 }},
+            ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain@${{ needs.build-toolchain.outputs.digest-arm64 }}
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:latest,
+            ghcr.io/${{ env.OWNER_LC }}/deeploy-toolchain:${{ needs.prepare.outputs.docker_tag }}
           push: true

--- a/.github/workflows/BuildDockerToolchain.yml
+++ b/.github/workflows/BuildDockerToolchain.yml
@@ -41,7 +41,7 @@ jobs:
           - platform: arm64
             runner: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -51,17 +51,18 @@ jobs:
           haskell: true
           large-packages: true
 
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v3
 
       - name: GHCR Log-in
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Cache for Docker
-        uses: actions/cache@v3
+        id: cache
+        uses: actions/cache@v4
         with:
           path: var-ccache
           key: ${{ runner.os }}-${{ matrix.platform }}-build-cache-toolchain
@@ -98,7 +99,7 @@ jobs:
     needs: [ prepare, build-toolchain ]
     steps:
       - name: GHCR Log-in
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 ## Unreleased (Planned Release Target: v0.2.1)
 ### List of Pull Requests
 - Prepare Post v0.2.0 Release [#104](https://github.com/pulp-platform/Deeploy/pull/104)
+- Use Docker digests instead of arch-specific tags [#106](https://github.com/pulp-platform/Deeploy/pull/106)
 
 ### Added
-- 
+- Output Docker image digests per platform (`amd64`, `arm64`) after build, which is used to construct the multi-arch Docker manifest. This preventes registry clutter caused by unnecessary per-architecture Docker tags.
 
 ### Changed
--
+- Replaced platform-specific tags (`*-amd64`, `*-arm64`) with direct digest references in `Noelware/docker-manifest-action`.
 
 ### Fixed
--
+- Resolved issue with missing `id` in the `Build Cache for Docker` step, used in the `Inject build-cache` step.
 
 ### Removed
 -


### PR DESCRIPTION
This PR improves the Docker image publishing workflow by switching from per-architecture tags to digest-based references when assembling multi-architecture manifests. This simplifies the tagging strategy and avoids excessive tag proliferation in the container registry. It also includes minor CI fixes and version bumps.

- New Toolchain Image Workflow: https://github.com/Xeratec/Deeploy/actions/runs/16173929110
- New Deeploy Image Workflow: https://github.com/Xeratec/Deeploy/actions/runs/16177376174

- Toolchain Container: https://github.com/Xeratec/Deeploy/pkgs/container/deeploy-toolchain
- Deeploy Container: https://github.com/Xeratec/Deeploy/pkgs/container/deeploy 

## Added
- Output Docker image digests per platform (`amd64`, `arm64`) after build, which is used to construct the multi-arch Docker manifest. This prevents registry clutter caused by unnecessary per-architecture Docker tags.

## Changed
- Replaced platform-specific tags (`*-amd64`, `*-arm64`) with direct digest references in `Noelware/docker-manifest-action`.

## Fixed
- Resolved issue with missing `id` in the `Build Cache for Docker` step, used in the `Inject build-cache` step.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and points to `devel`.
2. [x] Your PR was reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
