### PR TITLE
Refactor Logging for Improved Debugging

### DIFF
--- a/Deeploy/AbstractDataTypes.py
+++ b/Deeploy/AbstractDataTypes.py
@@ -188,6 +188,10 @@ class IntegerImmediate(Immediate[Union[int, Iterable[int]], _ImmediateType]):
         else:
             return 0
 
+    @_classproperty
+    def nLevels(cls) -> int:
+        return cls.typeMax - cls.typeMin + 1
+
     @classmethod
     def partialOrderUpcast(cls, otherCls: Type[Immediate]) -> bool:
         if issubclass(otherCls, IntegerImmediate):
@@ -212,6 +216,10 @@ class IntegerImmediate(Immediate[Union[int, Iterable[int]], _ImmediateType]):
         if _min < cls.typeMin:
             return False
         return True
+
+    @classmethod
+    def checkNumLevels(cls, nLevels: int, signed: bool) -> bool:
+        return nLevels <= (cls.typeMax - cls.typeMin + 1)
 
 
 class FloatImmediate(Immediate[Union[float, Iterable[float]], _ImmediateType]):
@@ -331,6 +339,10 @@ class Pointer(BaseType[Optional[str], _PointerType]):
         else:
             value = _value
         return cls.checkValue(value, ctxt)
+
+    @classmethod
+    def checkNumLevels(cls, nLevels: int, signed: bool) -> bool:
+        return cls.referencedType.checkNumLevels(nLevels, signed)
 
     def __init__(self, _value: Union[Optional[str], Pointer], ctxt: Optional[_NetworkContext] = None):
         """Initializes a pointer to a registered object in the NetworkContext

--- a/Deeploy/AbstractDataTypes.py
+++ b/Deeploy/AbstractDataTypes.py
@@ -21,6 +21,8 @@ _StructType = TypeVar("Struct", bound = "Struct")
 _DeeployType = TypeVar("_DeeployType", _PointerType, _ImmediateType, _StructType)
 _PythonType = TypeVar("_PythonType", str, int, float, Dict[str, "_PythonType"], Iterable["_PythonType"])
 
+from Deeploy.Logging import DEFAULT_LOGGER as log
+
 
 class _ClassPropertyDescriptor(object):
 
@@ -316,7 +318,7 @@ class Pointer(BaseType[Optional[str], _PointerType]):
             return False
 
         if value is None or value == "NULL":
-            print("WARNING: Setting pointer value to NULL - Referenced data is invalid!")
+            log.warning("Setting pointer value to NULL - Referenced data is invalid!")
             return True
 
         reference = ctxt.lookup(value)

--- a/Deeploy/CommonExtensions/NetworkDeployers/NetworkDeployerWrapper.py
+++ b/Deeploy/CommonExtensions/NetworkDeployers/NetworkDeployerWrapper.py
@@ -75,3 +75,9 @@ class NetworkDeployerWrapper(NetworkDeployer):
     # MultiEngineDeployer augment
     def _mapNode(self, node: gs.Node) -> Union[ONNXLayer, Any]:
         return self._innerObject._mapNode(node)
+
+    def _printMemorySummary(self):
+        return self._innerObject._printMemorySummary()
+
+    def _printInputOutputSummary(self):
+        return self._innerObject._printInputOutputSummary()

--- a/Deeploy/CommonExtensions/NetworkDeployers/SignPropDeployer.py
+++ b/Deeploy/CommonExtensions/NetworkDeployers/SignPropDeployer.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Type
 import onnx_graphsurgeon as gs
 
 from Deeploy.AbstractDataTypes import Pointer
-from Deeploy.DeeployTypes import CodeGenVerbosity, DeploymentPlatform, NetworkDeployer, TopologyOptimizer, _NoVerbosity
+from Deeploy.DeeployTypes import DeploymentPlatform, NetworkDeployer, TopologyOptimizer
 from Deeploy.Logging import DEFAULT_LOGGER as log
 
 
@@ -43,23 +43,11 @@ class SignPropDeployer(NetworkDeployer):
 
         return ctxt
 
-    def generateFunction(self, verbose: CodeGenVerbosity = _NoVerbosity) -> str:
-        """Helper function to prepare deployment and return generated function code
-
-        """
-
-        if not self.prepared:
-            self.prepare(verbose = verbose)
-
-        log.info("=" * 80)
-        log.info("Deeploy Code Generation")
-        log.info("=" * 80)
-
+    def _printInputOutputSummary(self):
         log.info('Input:')
-        for name in self.inputTypes.keys():
-            buf = self.ctxt.lookup(name)
+        for buf in self.inputs():
             log.info(
-                f" - '{name}': Type: {buf._type.referencedType.typeName}, nLevels: {buf.nLevels}, Signed: {buf._signed}, Offset: {self.inputOffsets[name]}"
+                f" - '{buf.name}': Type: {buf._type.referencedType.typeName}, nLevels: {buf.nLevels}, Signed: {buf._signed}, Offset: {self.inputOffsets[buf.name]}"
             )
 
         log.info('Output:')
@@ -67,11 +55,3 @@ class SignPropDeployer(NetworkDeployer):
             log.info(
                 f" - '{buf.name}': Type: {buf._type.referencedType.typeName}, nLevels: {buf.nLevels}, Signed: {buf._signed}"
             )
-
-        log.info("-" * 80)
-        num_ops = self.numberOfOps(verbose = True)
-        log.info("-" * 80)
-        log.info(f"Number of Ops.                : {num_ops}")
-        log.info(f"Model Parameters              : {self.getParameterSize()}")
-
-        return self.generateInferenceCode()

--- a/Deeploy/CommonExtensions/OptimizationPasses/PassClasses.py
+++ b/Deeploy/CommonExtensions/OptimizationPasses/PassClasses.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 import onnx_graphsurgeon as gs
 
 from Deeploy.DeeployTypes import NetworkContext
+from Deeploy.Logging import DEFAULT_LOGGER as log
 
 from .Matchers import Match, NonBranchingMatcher, SubgraphMatcher
 
@@ -129,7 +130,7 @@ class Pass():
         try:
             del self._subpasses[name]
         except KeyError:
-            print(f"No subpass with name {name}, cannot remove!")
+            log.error(f"No subpass with name {name}, cannot remove!")
         except AttributeError:
             raise AttributeError("Cannot remove sub-pass before calling Pass.__init__!")
 

--- a/Deeploy/CommonExtensions/TypeCheckers/SignPropTypeChecker.py
+++ b/Deeploy/CommonExtensions/TypeCheckers/SignPropTypeChecker.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import onnx_graphsurgeon as gs
 
+from Deeploy.AbstractDataTypes import IntegerImmediate
 from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, NodeTypeChecker, OperatorRepresentation, VariableBuffer
 
 
@@ -45,9 +46,14 @@ class SignPropTypeChecker(NodeTypeChecker):
         if signProp:
             nLevels = self._inferNumLevels(inputs, operatorRepresentation)
             signedness = self._inferSignedness(inputs, operatorRepresentation)
-
-            for obj, nLevels, sign in zip(outputs, nLevels, signedness):
-                obj.nLevels = nLevels
+            for obj, nLevel, sign in zip(outputs, nLevels, signedness):
+                obj.nLevels = nLevel
                 obj._signed = sign
+
+                if issubclass(obj._type.referencedType,
+                              IntegerImmediate) and not obj._type.checkNumLevels(nLevel, sign):
+                    print(
+                        f"[WARNING] {obj.name} has {nLevel} levels, but {obj._type.referencedType.typeName} only supports {obj._type.referencedType.nLevels} levels."
+                    )
 
         return ctxt

--- a/Deeploy/CommonExtensions/TypeCheckers/SignPropTypeChecker.py
+++ b/Deeploy/CommonExtensions/TypeCheckers/SignPropTypeChecker.py
@@ -8,6 +8,7 @@ import onnx_graphsurgeon as gs
 
 from Deeploy.AbstractDataTypes import IntegerImmediate
 from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, NodeTypeChecker, OperatorRepresentation, VariableBuffer
+from Deeploy.Logging import DEFAULT_LOGGER as log
 
 
 class SignPropTypeChecker(NodeTypeChecker):
@@ -52,8 +53,8 @@ class SignPropTypeChecker(NodeTypeChecker):
 
                 if issubclass(obj._type.referencedType,
                               IntegerImmediate) and not obj._type.checkNumLevels(nLevel, sign):
-                    print(
-                        f"[WARNING] {obj.name} has {nLevel} levels, but {obj._type.referencedType.typeName} only supports {obj._type.referencedType.nLevels} levels."
+                    log.warning(
+                        f"{obj.name} has {nLevel} levels, but {obj._type.referencedType.typeName} only supports {obj._type.referencedType.nLevels} levels."
                     )
 
         return ctxt

--- a/Deeploy/DeeployTypes.py
+++ b/Deeploy/DeeployTypes.py
@@ -3541,8 +3541,8 @@ class NetworkDeployer(NetworkContainer):
     def _printMemorySummary(self):
         log.info("")
         log.info("Memory Usage Report:")
-        log.info(f"Level                 Total (bytes)   (Static + Dynamic)    ")
-        log.info("-" * 80)
+        log.info(f"  Level                 Total (bytes)   (Static + Dynamic)    ")
+        log.info("  " + "-" * 60)
 
         _worstCaseBufferSize = self.worstCaseBufferSize
         if len(_worstCaseBufferSize) == 0:
@@ -3561,7 +3561,7 @@ class NetworkDeployer(NetworkContainer):
 
             total = staticSize + dynamicSize
 
-            log.info(f"{level:<22}     {total:8,d}   "
+            log.info(f"  {level:<22}     {total:8,d}   "
                      f"({staticSize:6,d} + {dynamicSize:7,d})  ")
 
     def generateFunction(self, verbose: CodeGenVerbosity = _NoVerbosity) -> str:

--- a/Deeploy/FutureExtension/Bindings/AutoFutureBinding.py
+++ b/Deeploy/FutureExtension/Bindings/AutoFutureBinding.py
@@ -7,6 +7,7 @@ from typing import Optional
 from Deeploy.DeeployTypes import CodeTransformation, NetworkContext, NodeTemplate, NodeTypeChecker
 from Deeploy.FutureExtension.Bindings.FutureBinding import FutureBinding
 from Deeploy.FutureExtension.Future import Future
+from Deeploy.Logging import DEFAULT_LOGGER as log
 
 
 class AutoFutureBinding(FutureBinding):
@@ -21,7 +22,7 @@ class AutoFutureBinding(FutureBinding):
         futureOutputs = [idx for idx, output in enumerate(self.typeChecker.output_types) if issubclass(output, Future)]
 
         if len(futureOutputs) > 1:
-            raise Exception(f"{self} assigns more than one future output!")
+            raise ValueError(f"{self} assigns more than one future output!")
 
         if len(futureOutputs) == 1:
             self.stateReferenceType = self.typeChecker.output_types[futureOutputs[0]].stateReferenceType
@@ -31,7 +32,7 @@ class AutoFutureBinding(FutureBinding):
     def assignStateReferenceElement(self, ctxt) -> NetworkContext:
 
         if len(self.futureOutputs) > 1:
-            raise Exception(f"{self} assigns more than one future output!")
+            raise ValueError(f"{self} assigns more than one future output!")
 
         if len(self.futureOutputs) == 0:
             return ctxt
@@ -48,7 +49,7 @@ class AutoFutureBinding(FutureBinding):
                         stateElementCandidates.append(reference)
 
             if len(stateElementCandidates) == 1:
-                print(f"WARNING: Automagically assigning state Element of {self}")
+                log.warninging(f"Automagically assigning state Element of {self}")
                 for key, value in operatorRepresentation.items():
                     if type(value) == str and (ctxt.is_local(value) or ctxt.is_global(value)):
                         reference = ctxt.lookup(value)
@@ -56,6 +57,6 @@ class AutoFutureBinding(FutureBinding):
                             reference._instance.assignStateReference(stateElementCandidates[0], ctxt)
 
             else:
-                raise Exception(f"Can't assign a unique state element to {self} automagically!")
+                raise ValueError(f"Can't assign a unique state element to {self} automagically!")
 
         return ctxt

--- a/Deeploy/Logging.py
+++ b/Deeploy/Logging.py
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------------------
+#
+# File: Logging.py
+#
+# Last edited: 22.08.2025
+#
+# Copyright (C) 2025, ETH Zurich and University of Bologna.
+#
+# Author:
+# - Philip Wiese, ETH Zurich
+#
+# ----------------------------------------------------------------------
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup logging
+import logging
+
+import coloredlogs
+
+CONSOLE_LOG_FORMAT = "[%(name)s] %(message)s"
+FILE_LOG_FORMAT = "[%(name)s] [%(module)-15s] %(message)s"
+DETAILED_FILE_LOG_FORMAT = "[%(levelname)s] [%(name)s] [%(pathname)s:%(lineno)d] %(message)s"
+
+DEFAULT_LOGGER = logging.getLogger("Deeploy")
+DEFAULT_FMT = CONSOLE_LOG_FORMAT
+
+# Install default logging if not already installed
+if not DEFAULT_LOGGER.handlers:
+    coloredlogs.install(level = 'INFO', logger = DEFAULT_LOGGER, fmt = DEFAULT_FMT)

--- a/Deeploy/MemoryLevelExtension/NetworkDeployers/MemoryLevelDeployer.py
+++ b/Deeploy/MemoryLevelExtension/NetworkDeployers/MemoryLevelDeployer.py
@@ -128,9 +128,10 @@ class MemoryLevelAwareDeployer(NetworkDeployer):
         super().codeTransform(verbose)
 
     def _printMemorySummary(self):
+        log.info("")
         log.info("Memory Usage Report:")
-        log.info(f"{'Level':<22} {'Capacity (bytes)':>16}   {'Total':>8}   {'(Static + Dynamic)':<21} {'Usage':<6}")
-        log.info("-" * 80)
+        log.info(f"  {'Level':<14} {'Capacity (bytes)':>10} {'Total':>10} (    Static + Dynamic   ) (Usage )")
+        log.info("  " + "-" * 78)
 
         for level, dynamicSize in self.worstCaseBufferSize.items():
             staticSize = 0
@@ -142,8 +143,8 @@ class MemoryLevelAwareDeployer(NetworkDeployer):
             capacity = self.Platform.memoryHierarchy.memoryLevels[level].size
             total = staticSize + dynamicSize
 
-            log.info(f"{level:<22} {capacity:16,}   {total:8,d}   "
-                     f"({staticSize:6,d} + {dynamicSize:7,d})  "
+            log.info(f"  {level:<20} {capacity:10,} {total:10,d} "
+                     f"({staticSize:10,d} + {dynamicSize:10,d}) "
                      f"({total / capacity * 100:5.1f}%)")
 
 
@@ -204,9 +205,10 @@ class MemoryLevelAwareSignPropDeployer(SignPropDeployer):
         super().codeTransform(verbose)
 
     def _printMemorySummary(self):
+        log.info("")
         log.info("Memory Usage Report:")
-        log.info(f"{'Level':<22} {'Capacity (bytes)':>16}   {'Total':>8}   {'(Static + Dynamic)':<21} {'Usage':<6}")
-        log.info("-" * 80)
+        log.info(f"  {'Level':<14} {'Capacity (bytes)':>10} {'Total':>10} (    Static + Dynamic   ) (Usage )")
+        log.info("  " + "-" * 78)
 
         for level, dynamicSize in self.worstCaseBufferSize.items():
             staticSize = 0
@@ -218,8 +220,8 @@ class MemoryLevelAwareSignPropDeployer(SignPropDeployer):
             capacity = self.Platform.memoryHierarchy.memoryLevels[level].size
             total = staticSize + dynamicSize
 
-            log.info(f"{level:<22} {capacity:16,}   {total:8,d}   "
-                     f"({staticSize:6,d} + {dynamicSize:7,d})  "
+            log.info(f"  {level:<20} {capacity:10,} {total:10,d} "
+                     f"({staticSize:10,d} + {dynamicSize:10,d}) "
                      f"({total / capacity * 100:5.1f}%)")
 
 
@@ -271,9 +273,10 @@ class MemoryDeployerWrapper(NetworkDeployerWrapper):
         super().codeTransform(verbose)
 
     def _printMemorySummary(self):
+        log.info("")
         log.info("Memory Usage Report:")
-        log.info(f"{'Level':<22} {'Capacity (bytes)':>16}   {'Total':>8}   {'(Static + Dynamic)':<21} {'Usage':<6}")
-        log.info("-" * 80)
+        log.info(f"  {'Level':<14} {'Capacity (bytes)':>10} {'Total':>10} (    Static + Dynamic   ) (Usage )")
+        log.info("  " + "-" * 78)
 
         for level, dynamicSize in self.worstCaseBufferSize.items():
             staticSize = 0
@@ -285,6 +288,6 @@ class MemoryDeployerWrapper(NetworkDeployerWrapper):
             capacity = self.Platform.memoryHierarchy.memoryLevels[level].size
             total = staticSize + dynamicSize
 
-            log.info(f"{level:<22} {capacity:16,}   {total:8,d}   "
-                     f"({staticSize:6,d} + {dynamicSize:7,d})  "
+            log.info(f"  {level:<20} {capacity:10,} {total:10,d} "
+                     f"({staticSize:10,d} + {dynamicSize:10,d}) "
                      f"({total / capacity * 100:5.1f}%)")

--- a/Deeploy/Targets/Chimera/Platform.py
+++ b/Deeploy/Targets/Chimera/Platform.py
@@ -47,9 +47,11 @@ class ChimeraStructBuffer(StructBuffer):
     deallocTemplate = NodeTemplate("")
 
 
-ChimeraOptimizer = TopologyOptimizer([
-    # JUNGVI: Nothing for now
-])
+ChimeraOptimizer = TopologyOptimizer(
+    [
+        # JUNGVI: Nothing for now
+    ],
+    name = "ChimeraOptimizer")
 
 _includeList = [
     "uart.h",

--- a/Deeploy/Targets/CortexM/Platform.py
+++ b/Deeploy/Targets/CortexM/Platform.py
@@ -123,18 +123,20 @@ class CMSISStructBuffer(StructBuffer):
 
 
 # ExtractPaddingFromConvPass(),ExtractPaddingFromPoolPass(),
-CMSISOptimizer = TopologyOptimizer([
-    IntegerDivRequantMergePass(),
-    iGELURequantMergePass(),
-    LinearAttentionAlignmentPass(),
-    MHSAAlignmentPass(),
-    MergeConstAddAndRequantPass(),
-    ConvRequantMergePass(),
-    GEMMRequantMergePass(),
-    MatMulRequantMergePass(),
-    # DebugPass("Conv", position='before'),
-    # DebugPass("Pad", position='after'),
-])
+CMSISOptimizer = TopologyOptimizer(
+    [
+        IntegerDivRequantMergePass(),
+        iGELURequantMergePass(),
+        LinearAttentionAlignmentPass(),
+        MHSAAlignmentPass(),
+        MergeConstAddAndRequantPass(),
+        ConvRequantMergePass(),
+        GEMMRequantMergePass(),
+        MatMulRequantMergePass(),
+        # DebugPass("Conv", position='before'),
+        # DebugPass("Pad", position='after'),
+    ],
+    name = "CMSISOptimizer")
 
 includeList = ["arm_nnfunctions.h", "DeeployMath.h"]
 

--- a/Deeploy/Targets/Generic/Platform.py
+++ b/Deeploy/Targets/Generic/Platform.py
@@ -142,17 +142,19 @@ class GenericStructBuffer(StructBuffer):
     deallocTemplate = NodeTemplate("")
 
 
-GenericOptimizer = TopologyOptimizer([
-    QuantPatternPass(),
-    DequantPatternPass(),
-    iGELURequantMergePass(),
-    MatMulAddMergePass(),
-    MergeConstAddAndRequantPass(),
-    ExtractPaddingFromConvPass(),
-    ExtractPaddingFromPoolPass(),
-    RemoveEmptyConvBiasPass(),
-    # DebugPrintPass(r'.*[Mm]at[Mm]ul.*', position = 'after'),
-])
+GenericOptimizer = TopologyOptimizer(
+    [
+        QuantPatternPass(),
+        DequantPatternPass(),
+        iGELURequantMergePass(),
+        MatMulAddMergePass(),
+        MergeConstAddAndRequantPass(),
+        ExtractPaddingFromConvPass(),
+        ExtractPaddingFromPoolPass(),
+        RemoveEmptyConvBiasPass(),
+        # DebugPrintPass(r'.*[Mm]at[Mm]ul.*', position = 'after'),
+    ],
+    name = "GenericOptimizer")
 
 includeList = ["DeeployBasicMath.h"]
 

--- a/Deeploy/Targets/MemPool/Platform.py
+++ b/Deeploy/Targets/MemPool/Platform.py
@@ -163,22 +163,24 @@ class MemPoolStructBuffer(StructBuffer):
     deallocTemplate = NodeTemplate("")
 
 
-MemPoolOptimizer = TopologyOptimizer([
-    MemPoolFuseMHSAPass(H = 8, bias = False, preSoftMaxRQ = True, integerDiv = False),
-    MemPoolFuseMHSAPass(H = 1, bias = False, preSoftMaxRQ = True, integerDiv = False),
-    MemPoolFuseMHSAPass(H = -1, bias = False, preSoftMaxRQ = True, integerDiv = False),
-    MemPoolFuseMHSAPass(H = -1, bias = True, preSoftMaxRQ = True, integerDiv = False),
-    MemPoolSplitMHSAPass(),
-    iGELURequantMergePass(),
-    MatMulAddMergePass(),
-    SplitAddPass(),
-    MergeConstAddAndRequantPass(),
-    MemPoolMatMulRequantMergePass(),
-    MemPoolGEMMRequantMergePass(),
-    ExtractPaddingFromConvPass(),
-    ExtractPaddingFromPoolPass(),
-    # DebugPrintPass(r'.*[Mm]at[Mm]ul.*', position = 'after'),
-])
+MemPoolOptimizer = TopologyOptimizer(
+    [
+        MemPoolFuseMHSAPass(H = 8, bias = False, preSoftMaxRQ = True, integerDiv = False),
+        MemPoolFuseMHSAPass(H = 1, bias = False, preSoftMaxRQ = True, integerDiv = False),
+        MemPoolFuseMHSAPass(H = -1, bias = False, preSoftMaxRQ = True, integerDiv = False),
+        MemPoolFuseMHSAPass(H = -1, bias = True, preSoftMaxRQ = True, integerDiv = False),
+        MemPoolSplitMHSAPass(),
+        iGELURequantMergePass(),
+        MatMulAddMergePass(),
+        SplitAddPass(),
+        MergeConstAddAndRequantPass(),
+        MemPoolMatMulRequantMergePass(),
+        MemPoolGEMMRequantMergePass(),
+        ExtractPaddingFromConvPass(),
+        ExtractPaddingFromPoolPass(),
+        # DebugPrintPass(r'.*[Mm]at[Mm]ul.*', position = 'after'),
+    ],
+    name = "MemPoolOptimizer")
 
 includeList = ["DeeployMath.h", "runtime.h", "synchronization.h"]
 

--- a/Deeploy/Targets/Neureka/Platform.py
+++ b/Deeploy/Targets/Neureka/Platform.py
@@ -18,7 +18,7 @@ from Deeploy.Targets.PULPOpen.Platform import MemoryPULPPlatform, MemoryPULPPlat
 NeurekaOptimizer = TopologyOptimizer([
     *PULPOptimizer.passes,
     RequantizedGemmToPwPass(),
-])
+], name = "NeurekaOptimizer")
 
 
 class NeurekaConstantBuffer(ConstantBuffer):

--- a/Deeploy/Targets/PULPOpen/Platform.py
+++ b/Deeploy/Targets/PULPOpen/Platform.py
@@ -226,7 +226,8 @@ PULPOptimizer = TopologyOptimizer([
     PULPGEMMRequantMergePass(),
     PULPMatMulRequantMergePass(),
     PULPAddRequantMergePass()
-])
+],
+                                  name = "PULPOptimizer")
 
 # SCHEREMO: stdint is included before pulp_nn_kernels.h because it is supposed to be included in there, but isn't...
 _includeList = [

--- a/Deeploy/Targets/Snitch/Platform.py
+++ b/Deeploy/Targets/Snitch/Platform.py
@@ -138,7 +138,8 @@ SnitchOptimizer = TopologyOptimizer([
     MergeConstAddAndRequantPass(),
     AddRequantMergePass(),
     GEMMRequantMergePass(),
-])
+],
+                                    name = "SnitchOptimizer")
 
 _includeList = [
     "snrt.h",

--- a/Deeploy/Targets/SoftHier/Platform.py
+++ b/Deeploy/Targets/SoftHier/Platform.py
@@ -91,7 +91,7 @@ class SoftHierStructBuffer(StructBuffer):
     deallocTemplate = NodeTemplate("")
 
 
-SoftHierOptimizer = TopologyOptimizer([])
+SoftHierOptimizer = TopologyOptimizer([], name = "SoftHierOptimizer")
 includeList = ["DeeployBasicMath.h", "flex_alloc_api.h"]
 
 

--- a/Deeploy/TilingExtension/MemoryScheduler.py
+++ b/Deeploy/TilingExtension/MemoryScheduler.py
@@ -553,7 +553,7 @@ class MemoryScheduler():
                     if memoryLevel.name == infoDict['memoryLevel']:
                         sumExpr += infoDict['sizeVar'] * infoDict['typeWidthFactor'] * infoDict['multiBufferCoeff']
                 if sumExpr != 0:
-                    tilerModel.addConstraint(sumExpr + constantTensorOffset <= memoryLevel.size)
+                    tilerModel.addConstraint(sumExpr + constantTensorOffset, memoryLevel = memoryLevel)
 
     def getSymbolicCostName(self, patternIdx: int, memoryLevel: str) -> str:
         stringSuffix = self._stringSuffix + f"_{memoryLevel}"

--- a/Deeploy/TilingExtension/TilerExtension.py
+++ b/Deeploy/TilingExtension/TilerExtension.py
@@ -21,8 +21,8 @@ from ortools.constraint_solver.pywrapcp import IntVar, SolutionCollector
 import Deeploy.CommonExtensions.DataTypes as BasicDataTypes
 from Deeploy.AbstractDataTypes import PointerClass
 from Deeploy.CommonExtensions.NetworkDeployers.NetworkDeployerWrapper import NetworkDeployerWrapper
-from Deeploy.DeeployTypes import CodeGenVerbosity, ConstantBuffer, NetworkContext, NodeBinding, NodeTemplate, \
-    ONNXLayer, Schedule, SubGraph, TransientBuffer, _NoVerbosity
+from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, NodeBinding, NodeTemplate, ONNXLayer, Schedule, \
+    SubGraph, TransientBuffer
 from Deeploy.Logging import DEFAULT_LOGGER as log
 from Deeploy.MemoryLevelExtension.MemoryLevels import MemoryHierarchy, MemoryLevel
 from Deeploy.MemoryLevelExtension.NetworkDeployers.MemoryLevelDeployer import MemoryDeployerWrapper, \
@@ -1000,10 +1000,7 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
         self.tile()
         return True
 
-    def generateFunction(self, verbose: CodeGenVerbosity = _NoVerbosity) -> str:
-        code = super().generateFunction(verbose)
-
-        log.info("")
+    def _printMemorySummary(self):
         log.info("Memory Usage Report:")
         log.info(f"{'Level':<22} {'Capacity (bytes)':>16}   {'Total':>8}   {'(Static + Dynamic)':<21} {'Usage':<6}")
         log.info("-" * 80)
@@ -1016,7 +1013,6 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
             log.info(f"{level:<22} {capacity:16,}   {total:8,d}   "
                      f"({staticSize:6,d} + {dynamicSize:7,d})  "
                      f"({total / capacity * 100:5.1f}%)")
-        return code
 
 
 def TilingReadyNodeBindings(nodeBindings: List[NodeBinding], tileConstraint: TileConstraint) -> List[NodeBinding]:

--- a/Deeploy/TilingExtension/TilerExtension.py
+++ b/Deeploy/TilingExtension/TilerExtension.py
@@ -106,6 +106,12 @@ class Tiler():
 
             for memoryMapStep in memoryMap[memoryLevel.name]:
                 for buffer in memoryMapStep:
+                    if not hasattr(buffer, "_addrSpace") or buffer._addrSpace is None:
+                        log.warning(
+                            f"Buffer {buffer.name} has no address space assigned, skipping it in the memory allocation plot."
+                        )
+                        continue
+
                     fig.add_trace(
                         go.Scatter(x = [
                             buffer._lifetime[0] - 0.5, buffer._lifetime[0] - 0.5, buffer._lifetime[1] + 0.5,

--- a/Deeploy/TilingExtension/TilerExtension.py
+++ b/Deeploy/TilingExtension/TilerExtension.py
@@ -21,8 +21,9 @@ from ortools.constraint_solver.pywrapcp import IntVar, SolutionCollector
 import Deeploy.CommonExtensions.DataTypes as BasicDataTypes
 from Deeploy.AbstractDataTypes import PointerClass
 from Deeploy.CommonExtensions.NetworkDeployers.NetworkDeployerWrapper import NetworkDeployerWrapper
-from Deeploy.DeeployTypes import ConstantBuffer, NetworkContext, NodeBinding, NodeTemplate, ONNXLayer, Schedule, \
-    SubGraph, TransientBuffer
+from Deeploy.DeeployTypes import CodeGenVerbosity, ConstantBuffer, NetworkContext, NodeBinding, NodeTemplate, \
+    ONNXLayer, Schedule, SubGraph, TransientBuffer, _NoVerbosity
+from Deeploy.Logging import DEFAULT_LOGGER as log
 from Deeploy.MemoryLevelExtension.MemoryLevels import MemoryHierarchy, MemoryLevel
 from Deeploy.MemoryLevelExtension.NetworkDeployers.MemoryLevelDeployer import MemoryDeployerWrapper, \
     MemoryLevelAwareDeployer, MemoryPlatform, MemoryPlatformWrapper, TargetMemoryLevelMapping
@@ -271,8 +272,8 @@ class Tiler():
                                           text = True)
 
         if minimallocOutput.returncode != 0:
-            print(
-                f"\033[91mError: Memory allocator failed with return code {minimallocOutput.returncode} at memory level {memoryLevel} with capacity of {capacity} bytes \033[0m"
+            log.error(
+                f"Memory allocator failed with return code {minimallocOutput.returncode} at memory level {memoryLevel} with capacity of {capacity} bytes!"
             )
             raise subprocess.CalledProcessError(minimallocOutput.returncode, " ".join(minimallocOutput.args))
 
@@ -292,6 +293,7 @@ class Tiler():
         tilingSolution = self._getTilingSolution(self.tilerModel, ctxt, collector, self.symbolicMemoryConstraints)
         if not self.memoryAllocStrategy == "MiniMalloc":
             assert self.tilerModel is not None
+            log.debug(" - Extract Memory Allocation")
             self.innerMemoryScheduler.annotateSolution(ctxt, self.tilerModel)
             self.outerMemoryScheduler.annotateSolution(ctxt, self.tilerModel)
         return tilingSolution
@@ -303,6 +305,7 @@ class Tiler():
             memoryMap[key] = [*self.innerMemoryScheduler.memoryMap[key], *self.outerMemoryScheduler.memoryMap[key]]
 
         if self.memoryAllocStrategy == "MiniMalloc":
+            log.debug(" - Solve Memory Allocation with MiniMalloc")
             for memoryLevel in memoryMap.keys():
                 constantTensorOffset = self.outerMemoryScheduler.getConstantTensorOffset(ctxt, memoryLevel)
                 if memoryLevel == self.memoryHierarchy._defaultMemoryLevel.name:
@@ -315,8 +318,7 @@ class Tiler():
                             memoryMap[memoryLevel][idx] = self.minimalloc(
                                 memMap, ctxt, tilingSolution[idx].nodeConstraints[0],
                                 self.memoryHierarchy.memoryLevels[memoryLevel].size - constantTensorOffset, memoryLevel)
-
-            print(f"\033[92mMemory allocation sucessful!\033[0m")
+            log.info(" ✓ Memory allocation successful!")
 
         return memoryMap
 
@@ -942,13 +944,7 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
 
     @property
     def worstCaseBufferSize(self):
-        maxAddr: Dict[str, int] = self.tiler.worstCaseBufferSize
-
-        # WIESEP: Memory map form tiler does not include inputs and outputs
-        for node in (self.inputs() + self.outputs()):
-            maxAddr[node._memoryLevel] += np.prod(node.shape) * node._type.referencedType.typeWidth // 8
-
-        return maxAddr
+        return self.tiler.worstCaseBufferSize
 
     def tile(self, tilingSolution: Optional[TilingSolution] = None, memoryMap: Optional[MemoryMap] = None):
         assert (tilingSolution is None and memoryMap is None) or (tilingSolution is not None and memoryMap is not None), \
@@ -964,6 +960,7 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
                     self.ctxt, self.Platform.memoryHierarchy._defaultMemoryLevel.name
                 ), "All tensors have to be in the default memory level when using MiniMalloc!"
 
+            log.debug(" - Setup Constraint Model")
             self.tiler.setupModel(ctxt = self.ctxt,
                                   schedule = schedule,
                                   layerBinding = self.layerBinding,
@@ -974,15 +971,19 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
 
         assert tilingSolution is not None and memoryMap is not None
 
+        log.debug(" - Test Tiling Solution Correctness")
         self.tiler.testTilingSolutionCorrectness(tilingSolution)
 
+        log.debug(" - Annotate Memory Levels")
         self.tiler.annotateMemoryLevel(self.ctxt, tilingSolution, memoryMap)
 
         self.ctxt = self.tiler._convertCtxtToStaticSchedule(self.ctxt, memoryMap)
 
         if self.tiler.visualizeMemoryAlloc:
+            log.info(f" > Export Memory Allocation Visualization to {self.deeployStateDir}")
             self.tiler.plotMemoryAlloc(memoryMap, self.ctxt, self.deeployStateDir, self.Platform.memoryHierarchy)
 
+        log.debug(" - Test Memory Map Correctness")
         self.tiler.testMemoryMapCorrectness(memoryMap, self.graph, schedule)
 
         # SCHEREMO: Annotate execution block with solution
@@ -995,8 +996,27 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
         if not super().bind():
             return False
 
+        log.info("- Performing Tiling and Memory Allocation")
         self.tile()
         return True
+
+    def generateFunction(self, verbose: CodeGenVerbosity = _NoVerbosity) -> str:
+        code = super().generateFunction(verbose)
+
+        log.info("")
+        log.info("Memory Usage Report:")
+        log.info(f"{'Level':<22} {'Capacity (bytes)':>16}   {'Total':>8}   {'(Static + Dynamic)':<21} {'Usage':<6}")
+        log.info("-" * 80)
+
+        for level, dynamicSize in self.worstCaseBufferSize.items():
+            staticSize = self.tiler.outerMemoryScheduler.getConstantTensorOffset(self.ctxt, level)
+            capacity = self.tiler.memoryHierarchy.memoryLevels[level].size
+            total = staticSize + dynamicSize
+
+            log.info(f"{level:<22} {capacity:16,}   {total:8,d}   "
+                     f"({staticSize:6,d} + {dynamicSize:7,d})  "
+                     f"({total / capacity * 100:5.1f}%)")
+        return code
 
 
 def TilingReadyNodeBindings(nodeBindings: List[NodeBinding], tileConstraint: TileConstraint) -> List[NodeBinding]:

--- a/Deeploy/TilingExtension/TilerExtension.py
+++ b/Deeploy/TilingExtension/TilerExtension.py
@@ -1001,17 +1001,18 @@ class TilerDeployerWrapper(NetworkDeployerWrapper):
         return True
 
     def _printMemorySummary(self):
+        log.info("")
         log.info("Memory Usage Report:")
-        log.info(f"{'Level':<22} {'Capacity (bytes)':>16}   {'Total':>8}   {'(Static + Dynamic)':<21} {'Usage':<6}")
-        log.info("-" * 80)
+        log.info(f"  {'Level':<14} {'Capacity (bytes)':>10} {'Total':>10} (    Static + Dynamic   ) (Usage )")
+        log.info("  " + "-" * 78)
 
         for level, dynamicSize in self.worstCaseBufferSize.items():
             staticSize = self.tiler.outerMemoryScheduler.getConstantTensorOffset(self.ctxt, level)
             capacity = self.tiler.memoryHierarchy.memoryLevels[level].size
             total = staticSize + dynamicSize
 
-            log.info(f"{level:<22} {capacity:16,}   {total:8,d}   "
-                     f"({staticSize:6,d} + {dynamicSize:7,d})  "
+            log.info(f"  {level:<20} {capacity:10,} {total:10,d} "
+                     f"({staticSize:10,d} + {dynamicSize:10,d}) "
                      f"({total / capacity * 100:5.1f}%)")
 
 

--- a/Deeploy/TilingExtension/TilerModel.py
+++ b/Deeploy/TilingExtension/TilerModel.py
@@ -103,6 +103,10 @@ class TilerModel():
                       constraintExpression: IntExpr,
                       memoryLevel: Optional[MemoryLevel] = None,
                       strategy: Optional[AddConstraintStrategy] = None):
+        # Skip TrueConstraints
+        if constraintExpression.DebugString() == "TrueConstraint()":
+            return
+
         if isinstance(strategy, PerformanceHint):
             if memoryLevel is None:
                 self._performanceConstraints.append((strategy.priority, constraintExpression))

--- a/Deeploy/TilingExtension/TilerModel.py
+++ b/Deeploy/TilingExtension/TilerModel.py
@@ -10,6 +10,7 @@ import numpy as np
 from ortools.constraint_solver.pywrapcp import IntExpr, IntVar, SolutionCollector, Solver
 
 from Deeploy.DeeployTypes import NetworkContext, OperatorRepresentation
+from Deeploy.Logging import DEFAULT_LOGGER as log
 from Deeploy.MemoryLevelExtension.MemoryLevels import MemoryLevel
 
 _COPYIDXSUFFIX = "_copyIdx_"
@@ -382,9 +383,11 @@ class TilerModel():
 
         timeLimit = self._model.TimeLimit(_SOLVERTIMEOUT)
 
-        log = self._model.SearchLog(1000000)
+        searchLog = self._model.SearchLog(1000000)
 
-        _ = self._model.Solve(decisionBuilder, [objective, collector, log, timeLimit])
+        log.debug(" - Solve Constraint Model")
+
+        _ = self._model.Solve(decisionBuilder, [objective, collector, None, timeLimit])
 
         assert collector.SolutionCount() > 0, "Error in Tiler: No solution found"
 

--- a/DeeployTest/testUtils/codeGenerate.py
+++ b/DeeployTest/testUtils/codeGenerate.py
@@ -73,6 +73,7 @@ def generateTestInputsHeader(deployer: NetworkDeployer, test_inputs: List) -> st
     retStr += f"void* testInputVector[{len(vectors)}] = {{"
     retStr += ", ".join(vectors)
     retStr += "};\n"
+
     return retStr
 
 
@@ -107,6 +108,7 @@ def generateTestOutputsHeader(deployer: NetworkDeployer, test_outputs: List[np.n
     retStr += f"void* testOutputVector[{len(test_outputs)}] = " + "{"
     retStr += ", ".join([f"testOutputVector{idx}" for idx, _ in enumerate(test_outputs)])
     retStr += "};\n"
+
     return retStr
 
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the codebase, focusing on enhanced logging, memory tracking, type checking, and developer usability. The most significant changes include replacing print statements with structured logging, adding detailed memory usage tracking for buffers, improving type and level checking for data types, and providing more informative string representations and debugging messages for core classes.

All runners and the generation scripts support different verbosity levels:
- `-v`: Show errors, warning and info messages
- `-vv`: Show errors, warnings, info and debug messages
- `-vvv`: Maximum verbosity with information about where the message was emitted. Also enable verbose compilation during the build step for the test runners.

## Added
- Logging and Error Handling Improvements: Replaced all `print` statements with structured logging using `DEFAULT_LOGGER` throughout the codebase, improving consistency and enabling better log management. 
- Added debug-level logs to type checking and parsing routines to indicate success/failure and binding exhaustion, aiding troubleshooting. 
- Implemented `__repr__` methods for core classes (`NodeTemplate`, `NodeBinding`, `NodeMapper`) to provide more informative string representations for debugging and logging
- Added `checkNumLevels` methods to relevant data type classes to validate that the number of levels assigned to buffers is supported by their type, and integrated warning logs if mismatches are detected during type inference.
- Introduced a `sizeInBytes` method to `VariableBuffer`, `TransientBuffer`, and related classes to standardize buffer size calculation. 

- Report the maximum static and dynamic memory usage for all memory level:
  - Added dynamic and maximum memory usage tracking to `NetworkContext` via `_dynamicSize` and `_maxDynamicSize` dictionaries, and updated memory allocation/deallocation logic in `MemoryAllocation.py` to maintain these statistics per memory level. (This is only used for untitled platforms to track the maximum buffer size.)
  - Exposed new summary methods (`_printMemorySummary`, `_printInputOutputSummary`) in deployer wrappers and implemented input/output summary logging in `SignPropDeployer`. 
  
## Changed
- 

## Fixed
-

## Example

<details>

<summary>Siracusa (Tiled) Debug Verbosity</summary>

```sh
➜  DeeployTest git:(pr/fix_doublebuffer) ✗ python testRunner_tiled_siracusa.py  -t Tests/testFloatGEMM  --l1 10000 -vv 
Generation Directory:  /app/Deeploy/DeeployTest/TEST_SIRACUSA/Tests/testFloatGEMM
Test Directory      :  Tests/testFloatGEMM
Test Name           :  testFloatGEMM
################## Testing Tests/testFloatGEMM on Siracusa Platform ##################
[TestRunner] Generation Command: python testMVP.py -d /app/Deeploy/DeeployTest/TEST_SIRACUSA/Tests/testFloatGEMM -t Tests/testFloatGEMM -p Siracusa  -vv --defaultMemLevel=L2 --l1=10000 --l2=1024000 --memAllocStrategy=MiniMalloc --searchStrategy=random-max
[Deeploy] Arguments: Namespace(dir='Tests/testFloatGEMM', platform='Siracusa', dumpdir='/app/Deeploy/DeeployTest/TEST_SIRACUSA/Tests/testFloatGEMM', verbose=2, debug=False, defaultMemLevel='L2', neureka_wmem=False, enable_3x3=False, enableStrides=False, doublebuffer=False, l1=10000, l2=1024000, shouldFail=False, memAllocStrategy='MiniMalloc', searchStrategy='random-max', profileTiling=False, plotMemAlloc=False)
[Deeploy] Platform: MemoryPULPPlatformWrapper(engines=['PULPCluster'], variableBuffer=PULPVariableBuffer, constantBuffer=PULPConstantBuffer, structBuffer=PULPStructBuffer, transientBuffer=PULPTransientBuffer) (sign: False)
[Deeploy] Platform Engines:
[Deeploy]  - PULPCluster: PULPClusterEngine(name='PULPCluster', mappings=['Conv', 'RequantizedConv', 'RequantizedGemm', 'Gemm', 'Gelu', 'LayerNormalization', 'MaxPool', 'RequantizediGELU', 'RQIntegerDiv', 'MatMul', 'IntegerMean', 'iSoftmax', 'Softmax', 'ReduceMean', 'ReduceSum', 'RequantShift', 'Add', 'Flatten', 'Gather', 'Mul', 'Pad', 'Relu', 'Reshape', 'Squeeze', 'Transpose', 'Unsqueeze', 'Slice', 'RequantizedAdd', 'Concat', 'iRMSNorm', 'iHardswish', 'RequantizediHardswish', 'Quant', 'Dequant', 'SoftmaxGrad', 'SoftmaxCrossEntropyLoss', 'SoftmaxCrossEntropyLossGrad', 'SGD', 'Constant'])
[Deeploy] Deployer: TilerDeployerWrapper(name='DeeployNetwork', platform=MemoryPULPPlatformWrapper, inputTypes=['float32_t*', 'float32_t*', 'float32_t*'], scheduler=_mockScheduler) (loweringOptimizer: PULPOptimizer, default_channels_first: False)
[Deeploy] ================================================================================
[Deeploy] Deeploy FrontEnd
[Deeploy] ================================================================================
[Deeploy] - Apply Preprocessing
[Deeploy]  - Remove Identity Nodes
[Deeploy]  - Mangle Tensor Names
[Deeploy]  - Mangle Node Names
[Deeploy]  - Sanitize Graph Names
[Deeploy]  - Remove Empty Inputs
[Deeploy]  - Duplicate Constants
[Deeploy]  - Constant Folding
[Deeploy] > Export State to middleware_pre_lowering[.onnx|.pkl]
[Deeploy] - Perform Graph Lowering
[Deeploy]  - Apply QuantPatternPass
[Deeploy]  - Apply DequantPatternPass
[Deeploy]  - Apply SkipEmptyConcatPass
[Deeploy]  - Apply SkipUnityRequantPass
[Deeploy]  - Apply SkipUnityRequantPass
[Deeploy]  - Apply SkipUnityRequantPass
[Deeploy]  - Apply RQSSplitPass
[Deeploy]  - Apply MergeTrueIntegerDivRequantShiftPass
[Deeploy]  - Apply IntegerDivRequantMergePass
[Deeploy]  - Apply iGELURequantMergePass
[Deeploy]  - Apply iHardswishRequantMergePass
[Deeploy]  - Apply PULPConvRequantMergePass
[Deeploy]  - Apply MergeConstAddAndRequantPass
[Deeploy]  - Apply PULPGEMMRequantMergePass
[Deeploy]  - Apply PULPMatMulRequantMergePass
[Deeploy]  - Apply PULPAddRequantMergePass
[Deeploy]  - Apply TransposeMatmulInputsPass
[Deeploy]  - Apply PULPNCHWtoNHWCPass
[Deeploy]  - Apply TransposeSplitPass
[Deeploy]  - Apply RQAddTransposeSquashPass
[Deeploy]  - Apply TransposeSplitPass
[Deeploy]  - Apply TransposeMergePass
[Deeploy]  - Apply TransposeConstOptPass
[Deeploy]  - Apply ReshapeConstOptPass
[Deeploy]  - Apply TransposeNoPermOptPass
[Deeploy]  - Apply RemoveGlobalOutputReshapePass
[Deeploy] > Export State middleware_post_lowering[.onnx|.pkl]
[Deeploy] - Perform Graph Parsing
[Deeploy]  - Create IO Bindings
[Deeploy]  - Bind Nodes to Layers
[Deeploy]    ✓ Bind  to layer GEMMLayer
[Deeploy]  - Parse and Type Check Network
[Deeploy] ------------------------------- MAIN ITERATION 1  -------------------------------
[Deeploy] [Layer 0] Trying '' (op: Gemm)
[Deeploy]  ✓ Parser GEMMParser succeeded
[Deeploy]  ✓ Context parsing succeeded with GEMMParser
[Deeploy]  ✓ Type check passed for NodeTemplate(float32_t, float32_t, float32_t) -> float32_t
[Deeploy]  ✓ Type check passed for NodeTemplate(float32_t, float32_t, float32_t) -> float32_t
[Deeploy]  ✓ Parsed network with 1 layers after 1 iterations
[Deeploy] ================================================================================
[Deeploy] Deeploy MidEnd
[Deeploy] ================================================================================
[Deeploy] - Map Layers to Bindings
[Deeploy]  ✓ Mapped  to NodeTemplate(float32_t, float32_t, float32_t) -> float32_t
[Deeploy] - Perform Memory Level Annotation
[Deeploy] - Performing Tiling and Memory Allocation
[Deeploy]  - Setup Constraint Model
[Deeploy]  - Solve Constraint Model
[Deeploy]  - Solve Memory Allocation with MiniMalloc
[Deeploy]  ✓ Memory allocation successful!
[Deeploy]  - Test Tiling Solution Correctness
[Deeploy]  - Annotate Memory Levels
[Deeploy]  - Test Memory Map Correctness
[Deeploy] > Export State backend_post_parsing[.onnx|.pkl]
[Deeploy] ================================================================================
[Deeploy] Deeploy BackEnd
[Deeploy] ================================================================================
[Deeploy] - Performing code transformations and optimization...
[Deeploy] > Export State backend_post_binding[.onnx|.pkl]
[Deeploy] ================================================================================
[Deeploy] Deeploy Code Generation
[Deeploy] ================================================================================
[Deeploy] Input:
[Deeploy]  - 'input_0': Type: float32_t, nLevels: 4294967296, Signed: True, Offset: 0
[Deeploy] Output:
[Deeploy]  - 'output_0': Type: float32_t, nLevels: 590295810358705651712, Signed: True
[Deeploy] Layer ''
[Deeploy]   Number of Operations        : 68608
[Deeploy] --------------------------------------------------------------------------------
[Deeploy] Number of Ops.                : 68608
[Deeploy] 
[Deeploy] Memory Usage Report:
[Deeploy]   Level          Capacity (bytes)      Total (    Static + Dynamic   ) (Usage )
[Deeploy]   ------------------------------------------------------------------------------
[Deeploy]   L3                   64,000,000          0 (         0 +          0) (  0.0%)
[Deeploy]   L2                    1,024,000     16,384 (     8,192 +      8,192) (  1.6%)
[Deeploy]   L1                       10,000     10,070 (        86 +      9,984) (100.7%)
```
</details>


<details>
<summary>Siracusa (Untiled) Debug Verbosity</summary>

```sh
➜  DeeployTest git:(pr/logging) ✗ python testRunner_siracusa.py -t Tests/testFloatGEMM  -vv 
Generation Directory:  /app/Deeploy/DeeployTest/TEST_SIRACUSA/Tests/testFloatGEMM
Test Directory      :  Tests/testFloatGEMM
Test Name           :  testFloatGEMM
################## Testing Tests/testFloatGEMM on Siracusa Platform ##################
[TestRunner] Generation Command: python generateNetwork.py -d /app/Deeploy/DeeployTest/TEST_SIRACUSA/Tests/testFloatGEMM -t Tests/testFloatGEMM -p Siracusa  -vv
[Deeploy] Arguments: Namespace(dir='Tests/testFloatGEMM', platform='Siracusa', dumpdir='/app/Deeploy/DeeployTest/TEST_SIRACUSA/Tests/testFloatGEMM', verbose=2, debug=False, profileUntiled=False, input_type_map=[], input_offset_map=[], shouldFail=False)
[Deeploy] Platform: PULPPlatform(engines=['PULPCluster'], variableBuffer=PULPVariableBuffer, constantBuffer=PULPConstantBuffer, structBuffer=PULPStructBuffer, transientBuffer=PULPTransientBuffer) (sign: False)
[Deeploy] Platform Engines:
[Deeploy]  - PULPCluster: PULPClusterEngine(name='PULPCluster', mappings=['Conv', 'RequantizedConv', 'RequantizedGemm', 'Gemm', 'Gelu', 'LayerNormalization', 'MaxPool', 'RequantizediGELU', 'RQIntegerDiv', 'MatMul', 'IntegerMean', 'iSoftmax', 'Softmax', 'ReduceMean', 'ReduceSum', 'RequantShift', 'Add', 'Flatten', 'Gather', 'Mul', 'Pad', 'Relu', 'Reshape', 'Squeeze', 'Transpose', 'Unsqueeze', 'Slice', 'RequantizedAdd', 'Concat', 'iRMSNorm', 'iHardswish', 'RequantizediHardswish', 'Quant', 'Dequant', 'SoftmaxGrad', 'SoftmaxCrossEntropyLoss', 'SoftmaxCrossEntropyLossGrad', 'SGD'])
[Deeploy] Deployer: PULPDeployer(name='DeeployNetwork', platform=PULPPlatform, inputTypes=['float32_t*', 'float32_t*', 'float32_t*'], scheduler=defaultScheduler) (loweringOptimizer: PULPOptimizer, default_channels_first: False)
[Deeploy] ================================================================================
[Deeploy] Deeploy FrontEnd
[Deeploy] ================================================================================
[Deeploy] - Apply Preprocessing
[Deeploy]  - Remove Identity Nodes
[Deeploy]  - Mangle Tensor Names
[Deeploy]  - Mangle Node Names
[Deeploy]  - Sanitize Graph Names
[Deeploy]  - Remove Empty Inputs
[Deeploy]  - Duplicate Constants
[Deeploy]  - Constant Folding
[Deeploy] > Export State to middleware_pre_lowering[.onnx|.pkl]
[Deeploy] - Perform Graph Lowering
[Deeploy]  - Apply EmulateCMSISRequantPass
[Deeploy]  - Apply QuantPatternPass
[Deeploy]  - Apply DequantPatternPass
[Deeploy]  - Apply SkipEmptyConcatPass
[Deeploy]  - Apply SkipUnityRequantPass
[Deeploy]  - Apply SkipUnityRequantPass
[Deeploy]  - Apply SkipUnityRequantPass
[Deeploy]  - Apply RQSSplitPass
[Deeploy]  - Apply MergeTrueIntegerDivRequantShiftPass
[Deeploy]  - Apply IntegerDivRequantMergePass
[Deeploy]  - Apply iGELURequantMergePass
[Deeploy]  - Apply iHardswishRequantMergePass
[Deeploy]  - Apply PULPConvRequantMergePass
[Deeploy]  - Apply MergeConstAddAndRequantPass
[Deeploy]  - Apply PULPGEMMRequantMergePass
[Deeploy]  - Apply PULPMatMulRequantMergePass
[Deeploy]  - Apply PULPAddRequantMergePass
[Deeploy]  - Apply TransposeMatmulInputsPass
[Deeploy]  - Apply PULPNCHWtoNHWCPass
[Deeploy]  - Apply TransposeSplitPass
[Deeploy]  - Apply RQAddTransposeSquashPass
[Deeploy]  - Apply TransposeSplitPass
[Deeploy]  - Apply TransposeMergePass
[Deeploy]  - Apply TransposeConstOptPass
[Deeploy]  - Apply ReshapeConstOptPass
[Deeploy]  - Apply TransposeNoPermOptPass
[Deeploy]  - Apply RemoveGlobalOutputReshapePass
[Deeploy] > Export State middleware_post_lowering[.onnx|.pkl]
[Deeploy] - Perform Graph Parsing
[Deeploy]  - Create IO Bindings
[Deeploy]  - Bind Nodes to Layers
[Deeploy]    ✓ Bind  to layer GEMMLayer
[Deeploy]  - Parse and Type Check Network
[Deeploy] ------------------------------- MAIN ITERATION 1  -------------------------------
[Deeploy] [Layer 0] Trying '' (op: Gemm)
[Deeploy]  ✓ Parser GEMMParser succeeded
[Deeploy]  ✓ Context parsing succeeded with GEMMParser
[Deeploy]  ✓ Type check passed for NodeTemplate(float32_t, float32_t, float32_t) -> float32_t
[Deeploy]  ✓ Parsed network with 1 layers after 1 iterations
[Deeploy] ================================================================================
[Deeploy] Deeploy MidEnd
[Deeploy] ================================================================================
[Deeploy] - Map Layers to Bindings
[Deeploy]  ✓ Mapped  to NodeTemplate(float32_t, float32_t, float32_t) -> float32_t
[Deeploy] > Export State backend_post_parsing[.onnx|.pkl]
[Deeploy] ================================================================================
[Deeploy] Deeploy BackEnd
[Deeploy] ================================================================================
[Deeploy] - Performing code transformations and optimization...
[Deeploy] > Export State backend_post_binding[.onnx|.pkl]
[Deeploy] ================================================================================
[Deeploy] Deeploy Code Generation
[Deeploy] ================================================================================
[Deeploy] Input:
[Deeploy]  - 'input_0': Type: float32_t, nLevels: 4294967296, Signed: True, Offset: 0
[Deeploy] Output:
[Deeploy]  - 'output_0': Type: float32_t, nLevels: 590295810358705651712, Signed: True
[Deeploy] Layer ''
[Deeploy]   Number of Operations        : 68608
[Deeploy] --------------------------------------------------------------------------------
[Deeploy] Number of Ops.                : 68608
[Deeploy] 
[Deeploy] Memory Usage Report:
[Deeploy]   Level                 Total (bytes)   (Static + Dynamic)    
[Deeploy]   ------------------------------------------------------------
[Deeploy]   None                         16,384   (16,384 +       0)
```
</details>

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [ ] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
