### PR TITLE
Extend Codeowners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 
 
 ### List of Pull Requests
+- Extend Codeowners [#164](https://github.com/pulp-platform/Deeploy/pull/164)
 - Support for MaxPool1D and RQSConv1D for PULPOpen [#146](https://github.com/pulp-platform/Deeploy/pull/146)
 - Use Pre-Commit in CI [#159](https://github.com/pulp-platform/Deeploy/pull/159)
 - Deeploy-GAP9 Platform [#143](https://github.com/pulp-platform/Deeploy/pull/143)
@@ -19,6 +20,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Update `pulp-nnx` and `pulp-nn-mixed` submodules to their latest versions
 - PULP-NN moved to TargetLibraries third-party folder
 - Aligned CLI commands across the project
+- Added @runwangdl as a code owner
 
 ### Fixed
 - im2col buffer size in Conv1d template

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: CC-BY-ND-4.0
 
-*       @victor-jung @xeratec @lukamac
+*       @victor-jung @xeratec @runwangdl

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,11 +1,16 @@
 All contributors have agreed to an open-source release of their work in the Deeploy project.
 
-* Moritz Scherer
-* Victor Jung
-* Philip Wiese
-* Luka Macan
-* Alberto Dequino
+This list contributors with significant contributions to the project, in alphabetical order:
+
+* Alex Marchioni
+* Bowen Wang
+* Călin Diaconu
+* Federico Brancasi
 * Francesco Conti
+* Luka Macan
+* Moritz Scherer
+* Philip Wiese
 * Run Wang
 * Taha El Bayad
-* Federico Brancasi
+* Victor Jung
+* Viviane Potocnik


### PR DESCRIPTION
This is a very small PR adding @runwangdl as a code owner and mentioning people in the `CONTRIBUTORS.md` for more than one merged PR. The reasoning is that we already keep track of contributions through `git`, and we only mention authors with significant contributions to the project.

## Changed
- Extended Codeowners
- Mention people with significant contributions

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR was reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the Docker was modified, change back its link after review.
