### PR TITLE
Fix CI cache generation workflows

### DIFF
--- a/.github/workflows/infra-generate-ccache-gap9.yml
+++ b/.github/workflows/infra-generate-ccache-gap9.yml
@@ -45,7 +45,7 @@ jobs:
           mkdir -p /app/.ccache
           export CCACHE_DIR=/app/.ccache
           pytest 'test_platforms.py::test_gap9_kernels[Kernels/Integer/Add/Regular]' --skipsim
-          pytest 'test_platforms.py::test_gap9_tiled_kernels_l2_singlebuffer[Kernels/Integer/Add/Large-5000-L2-singlebuffer]' --skipsim
+          pytest 'test_platforms.py::test_gap9_tiled_kernels_l2_singlebuffer[Kernels/Integer/MatMul/Regular-64000-L2-singlebuffer]' --skipsim
           deactivate
 
       - name: Clean and Upload CCache

--- a/.github/workflows/infra-generate-ccache-gap9.yml
+++ b/.github/workflows/infra-generate-ccache-gap9.yml
@@ -36,6 +36,7 @@ jobs:
           deactivate
 
       - name: Generate CCache for GAP9
+        shell: bash
         run: |
           source /app/install/gap9-sdk/.gap9-venv/bin/activate
           source /app/install/gap9-sdk/configs/gap9_evk_audio.sh || true

--- a/.github/workflows/infra-generate-ccache.yml
+++ b/.github/workflows/infra-generate-ccache.yml
@@ -31,6 +31,7 @@ jobs:
         run: pip install -e .
 
       - name: Generate CCache
+        shell: bash
         run: |
           cd DeeployTest
           mkdir -p /app/.ccache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 
 
 ### List of Pull Requests
+- Fix CI Cache Generation [#176](https://github.com/pulp-platform/Deeploy/pull/176)
 - Fix Broken CI [#175](https://github.com/pulp-platform/Deeploy/pull/175)
 - Improve Docstring and Debugging [#160](https://github.com/pulp-platform/Deeploy/pull/160)
 - Add GAP9 Container Support [#163](https://github.com/pulp-platform/Deeploy/pull/163)
@@ -38,6 +39,8 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Added @runwangdl as a code owner
 
 ### Fixed
+- Add missing `shell: bash` directive to CI cache generation steps to ensure correct shell execution
+- Fix wrong test case in GAP9 ccache workflow (`test_gap9_tiled_kernels_l2_singlebuffer` using `MatMul/Regular` instead of `Add/Large`)
 - Fix Docker flow to fetch `*.so` git lfs files
 - Downgrade `setuptools` to `81.0.0`
 - im2col buffer size in Conv1d template


### PR DESCRIPTION
Fix broken CI cache generation by adding missing `shell: bash` directive and correcting a test case reference.

See below for successful cache generation actions:
- GAP9: https://github.com/pulp-platform/Deeploy/actions/runs/23290279441 
- Others: https://github.com/pulp-platform/Deeploy/actions/runs/23290526544

## Changed
- Added `shell: bash` to the "Generate CCache" step in `infra-generate-ccache.yml` to ensure correct shell execution
- Added `shell: bash` to the "Generate CCache for GAP9" step in `infra-generate-ccache-gap9.yml` to ensure correct shell execution

## Fixed
- Fixed wrong test case in GAP9 ccache workflow: replaced `test_gap9_tiled_kernels_l2_singlebuffer[Kernels/Integer/Add/Large-5000-L2-singlebuffer]` with `test_gap9_tiled_kernels_l2_singlebuffer[Kernels/Integer/MatMul/Regular-64000-L2-singlebuffer]`

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.