### PR TITLE
Fix/tiling stack scoping and tiling information corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - im2col buffer size in Conv1d template
 - Fix missing dependency in pre-commit-config
 - Fix test paths in Deeploy 101 tutorial
+- Fix tiling variable replacement corrupting static arrays by changing pointer update from value copy to address reassignment
+- Reduce RunNetwork stack usage by scoping per-layer variables with braces and moving tileIdxPtr allocation into per-layer execution blocks
 
 ### Removed
 - `testDMA.py` was an old test; we now have `test_dmas.py` instead.

--- a/Deeploy/DeeployTypes.py
+++ b/Deeploy/DeeployTypes.py
@@ -2800,7 +2800,8 @@ class NetworkContainer():
             self.ctxt, code = node.generate(self.ctxt)
 
             sections = reduce(lambda a, b: a + b, code, [])
-            callStack += reduce(lambda a, b: a + b, sections, "")
+            layerCode = reduce(lambda a, b: a + b, sections, "")
+            callStack += "{\n" + layerCode + "\n}\n"
 
         return callStack
 

--- a/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
+++ b/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
@@ -92,11 +92,11 @@ class TilingHoistingMixIn:
         # LMACAN: Intentionally don't annotate memory level so it gets allocated
         # outside of the tiling loops
 
-        tileIdxPtr.allocTemplate = NodeTemplate("")
-        tileIdxPtr.deallocTemplate = NodeTemplate("")
-        tileIdxPtr.initTemplate = NodeTemplate("""
+        tileIdxPtr.allocTemplate = NodeTemplate("""
         ${type.referencedType.typeName} bu_${name} = 0;
         ${type.referencedType.typeName}* ${name} = &bu_${name};""")
+        tileIdxPtr.deallocTemplate = NodeTemplate("")
+        tileIdxPtr.initTemplate = NodeTemplate("")
 
         return (tileNum, tileIdxPtr)
 

--- a/Deeploy/TilingExtension/CodeTransformationPasses/TilingVariableReplacement.py
+++ b/Deeploy/TilingExtension/CodeTransformationPasses/TilingVariableReplacement.py
@@ -177,7 +177,7 @@ class TilingVariableReplacementUpdate(CodeTransformationPass, IntrospectiveCodeT
 
     _updateReferenceTemplate = NodeTemplate("""
     // UPDATE VARIABLE ${reference}
-    *${reference} = ${baseReference}[${tileIdxVar}];
+    ${reference} = &${baseReference}[${tileIdxVar}];
     """)
 
     def __init__(self, targetMemLevel: str, tileIdxVar: str = "TILING_I"):


### PR DESCRIPTION
Describe the intent of your PR here.

## Added
-

## Changed
-

## Fixed
This pull request address two issues: 

**1) Big stack usage in C code generated by Deeploy**
When the `RunNetwork` function is called, all the variables defined in the `RunNetwork` function lives in stack. This include the tiling pointers such as  `uint8_t bu_DeeployNetwork_TILING_CODEGEN_L1_<layer name>_tileIdxPtr` and `DeeployNetwork__<layer name>_closure_L3_args`. Originally, all tiling pointers and L3 clousure call arguements have scope acroos the entire `RunNetwork` function, which means tiling pointers and args for all layers live in the stack for the entire `RunNetwork` function. This causes extensive stack usage when entering the `RunNetwork`. This stack usage scale for number of layers,  more layers you have, more tiling pointers and call args you have, higher the stack usage is. (5KB in the L1 for a 90 layer network)

This fix is very simple. First, move the tiling pointers' declearation into layer code. Second, wrap each layer with a `{}`. So each layer the generated RunNetwork looks like:


```
{
Tiling pointer declearation
Call arg declearation
L3 closure call
}

{
Next layer
}
```
In this way, the tiling pointers and call arg's scope are constrained for the respective layer and we don't need tiling pointers and call args for all layers live in stack.

In my network with 93 layers, wrapping the call args with `{}` reduce the stack increment when entering `RunNetwork` from 5KB to 0.7KB. Putting the tiling pointers into  `{}`  as well further reduce the increment to 0.6KB.

**2) The tiling information is corrupted after the first `Runnetwork` run**

Originally, in the L1 tiling pointer code, the tiling pointer is updated by:

`*DeeployNetwork_TILING_CODEGEN_L1_<layer name>_size_ref = DeeployNetwork_TILING_CODEGEN_L1_<name>_size[TILING_I];`

This assign the next value from the tiling information array `DeeployNetwork_TILING_CODEGEN_L1_<name>_size[TILING_I]` to the referene. However, the refrence is defined pointer to the first element of the tiling information array. Thus, the next element in the tiling array is moved to the first element in the tiling information array, corrupting the tiling information.

Easy fix, simply pointer the reference to the next element instead of assigning value fix everything.

`DeeployNetwork_TILING_CODEGEN_L1_<layer name>_size_ref = &DeeployNetwork_TILING_CODEGEN_L1_<name>_size[TILING_I];`

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR reviewed and approved.
3. [ ] All checks are passing.
4. [ ] The `CHANGELOG.md` file has been updated.
5. [ ] If the docker was modified, change back its link after review.
