### PR TITLE
  [Deeploy PR] NE16 Linear Layer Kernels

### DIFF
--- a/Deeploy/Targets/GAP9/Bindings.py
+++ b/Deeploy/Targets/GAP9/Bindings.py
@@ -18,7 +18,7 @@ from Deeploy.CommonExtensions.DataTypes import FloatDataTypes, IntegerDataTypes,
 from Deeploy.DeeployTypes import CodeTransformation, NodeBinding
 from Deeploy.FutureExtension.Bindings.AutoFutureBinding import AutoFutureBinding
 from Deeploy.FutureExtension.CodeTransformationPasses.FutureCodeTransformation import FutureGeneration
-from Deeploy.Targets.GAP9.DMA.L3Dma import gap9L3DmaHack
+from Deeploy.Targets.GAP9.DMA.L3Dma import GAP9L3Dma
 from Deeploy.Targets.GAP9.DMA.MchanDma import GAP9MchanDma
 # Import templates from PULPOpen and Generic
 from Deeploy.Targets.Generic.Templates import AddTemplate, ConcatTemplate, DequantTemplate, FloatReduceMeanTemplate, \
@@ -34,6 +34,7 @@ from Deeploy.Targets.PULPOpen.CodeTransformationPasses.PULPClusterTiling import 
 from Deeploy.Targets.PULPOpen.CodeTransformationPasses.PULPL3Tiling import PULPL3Tiling
 from Deeploy.Targets.PULPOpen.CodeTransformationPasses.PULPProfileUntiled import PULPProfileUntiled
 from Deeploy.Targets.PULPOpen.DataTypes import PULPDMAFuture
+from Deeploy.Targets.GAP9.Templates import NE16GEMMTemplate
 from Deeploy.Targets.PULPOpen.Templates import ConvTemplate, DMASliceTemplate, FloatAddTemplate, FloatConvTemplate, \
     FloatGELUTemplate, FloatGemmTemplate, FloatLayernormTemplate, FloatMatMulTemplate, FloatMaxPoolTemplate, \
     FloatMulTemplate, FloatReluTemplate, FloatSoftmaxTemplate, GEMMTemplate, MatrixVectorTemplate, MaxPoolTemplate, \
@@ -44,6 +45,7 @@ from Deeploy.Targets.PULPOpen.TypeCheckers import PULPConvChecker, PULPLinearChe
     PULPRequantShiftChecker
 from Deeploy.TilingExtension.CodeTransformationPasses.TilingVariableReplacement import TilingVariableReplacement, \
     TilingVariableReplacementUpdate
+from Deeploy.Targets.GAP9.Templates import GAP9SDKDequantQuantTemplate
 
 # GAP9-specific transformer using cl_dma.h API
 GAP9Transformer = CodeTransformation([
@@ -57,7 +59,7 @@ GAP9Transformer = CodeTransformation([
     MemoryManagementGeneration("L1"),
     TilingVariableReplacement("L2"),
     MemoryAwareFunctionCallClosure(writeback = False, generateStruct = True),
-    PULPL3Tiling("L3", "L2", gap9L3DmaHack),  # Use GAP9-specific L3 DMA
+    PULPL3Tiling("L3", "L2", GAP9L3Dma()),  # Use GAP9-specific L3 DMA
     PULPProfileUntiled(),
     ArgumentStructGeneration(),
     L3MemoryAwareFunctionCallClosure(writeback = False),
@@ -76,7 +78,7 @@ GAP9ClusterTransformer = CodeTransformation([
     MemoryManagementGeneration("L1"),
     TilingVariableReplacement("L2"),
     MemoryAwareFunctionCallClosure(writeback = False, generateStruct = True),
-    PULPL3Tiling("L3", "L2", gap9L3DmaHack),  # Use GAP9-specific L3 DMA
+    PULPL3Tiling("L3", "L2", GAP9L3Dma()),  # Use GAP9-specific L3 DMA
     PULPProfileUntiled(),
     ArgumentStructGeneration(),
     L3MemoryAwareFunctionCallClosure(writeback = False),
@@ -181,6 +183,23 @@ GAP9RQSGEMM_8_Binding = [
                            PointerClass(int32_t),
                            PointerClass(int32_t)], [PointerClass(type2)]), GEMMTemplate.PULPGEMM_8_Template,
         GAP9Transformer) for type1, type2 in zip([int8_t, uint8_t, int8_t, uint8_t], [int8_t, uint8_t, uint8_t, int8_t])
+]
+
+GAP9NE16RQSGEMMBindings = [
+    NodeBinding(
+        PULPLinearChecker([PointerClass(type1),
+                           PointerClass(int8_t),
+                           PointerClass(int32_t),
+                           PointerClass(uint8_t),
+                           PointerClass(uint8_t)], [PointerClass(type2)]), NE16GEMMTemplate.referenceTemplate,
+        GAP9ClusterTransformer) for type1 in [int8_t, uint8_t] for type2 in [int8_t, uint8_t]
+]
+
+GAP9NE16GEMMInt32Bindings = [
+    NodeBinding(
+        GEMMChecker([PointerClass(type1), PointerClass(int8_t),
+                     PointerClass(int32_t)], [PointerClass(int32_t)]), NE16GEMMTemplate.int32OutputTemplate,
+        GAP9ClusterTransformer) for type1 in [int8_t, uint8_t]
 ]
 
 GAP9FloatGEMMBindings = [
@@ -386,14 +405,17 @@ GAP9GatherBindings = [
 ]
 
 GAP9QuantBindings = [
-    NodeBinding(QuantChecker([PointerClass(float32_t)], [PointerClass(int8_t)]), QuantTemplate.referenceTemplate,
+    NodeBinding(QuantChecker([PointerClass(float32_t)], [PointerClass(int8_t)]), GAP9SDKDequantQuantTemplate.fp32QuantI8Template,
+                GAP9Transformer),
+    NodeBinding(QuantChecker([PointerClass(float32_t)], [PointerClass(uint8_t)]), GAP9SDKDequantQuantTemplate.fp32QuantU8Template,
                 GAP9Transformer),
 ]
 
 GAP9DequantBindings = [
-    NodeBinding(DequantChecker([PointerClass(int8_t)], [PointerClass(float32_t)]), DequantTemplate.referenceTemplate,
+    NodeBinding(DequantChecker([PointerClass(int8_t)], [PointerClass(float32_t)]), GAP9SDKDequantQuantTemplate.fp32DequantI8Template,
                 GAP9Transformer),
-] + [
+    NodeBinding(DequantChecker([PointerClass(uint8_t)], [PointerClass(float32_t)]), GAP9SDKDequantQuantTemplate.fp32DequantU8Template,
+                GAP9Transformer),
     NodeBinding(DequantChecker([PointerClass(int32_t)], [PointerClass(float32_t)]), DequantTemplate.referenceTemplate,
                 GAP9Transformer),
 ]

--- a/Deeploy/Targets/GAP9/DMA/L3Dma.py
+++ b/Deeploy/Targets/GAP9/DMA/L3Dma.py
@@ -29,7 +29,7 @@ class GAP9L3Dma(AsyncDma):
     _transferTemplates = {
         2:
             NodeTemplate(
-                "pi_cl_ram_copy_2d(get_ram_ptr(), ${ext}, ${loc}, ${transfer_size}, ${stride}, ${length}, ${ext2loc}, &${future});"
+                "pi_cl_ram_copy_2d(get_ram_ptr(), (uint32_t)${ext}, (void *)${loc}, (uint32_t)${transfer_size}, (uint32_t)${stride}, (uint32_t)${length}, ${ext2loc}, &${future});"
             )
     }
     _waitingStrategy = PerTensorWaitingStrategy(GAP9L3DmaFuture)
@@ -60,5 +60,3 @@ class GAP9L3Dma(AsyncDma):
         return operatorRepresentation
 
 
-# Blocking adapter for L3 DMA (used in GAP9 L3 tiling)
-gap9L3DmaHack = BlockingDmaFromAsyncDmaAdapter(GAP9L3Dma())

--- a/Deeploy/Targets/GAP9/Parsers.py
+++ b/Deeploy/Targets/GAP9/Parsers.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Tuple
+
+import onnx_graphsurgeon as gs
+
+from Deeploy.DeeployTypes import NetworkContext
+from Deeploy.Targets.Generic.Parsers import GEMMParser, RQSParserInterface
+
+
+class NE16GEMMParser(GEMMParser, RQSParserInterface):
+    """Parser for NE16 RequantizedGemm nodes with 5 inputs [A, B, C, mul, scale_n]."""
+
+    def __init__(self):
+        super().__init__(noBiasHoisting = True)
+
+    def parseNode(self, node: gs.Node) -> bool:
+        ret_rqs = RQSParserInterface.parseNode(self, node)
+        ret_matmul = GEMMParser.parseNode(self, node)
+        ret = all([ret_rqs, ret_matmul, 'shift' in node.attrs, len(node.inputs) == 5])
+        if ret:
+            self.operatorRepresentation['shift'] = int(node.attrs['shift'].values)
+        return ret
+
+    def parseNodeCtxt(self, ctxt: NetworkContext, node: gs.Node,
+                      channels_first: bool = True) -> Tuple[NetworkContext, bool]:
+        newCtxt, ret = GEMMParser.parseNodeCtxt(self, ctxt, node, channels_first)
+        if ret:
+            inputs = ['A', 'B', 'C', 'mul', 'scale_n']
+            for idx, inputNode in enumerate(node.inputs):
+                self.operatorRepresentation[inputs[idx]] = newCtxt.lookup(inputNode.name).name
+            return newCtxt, True
+        return ctxt, False

--- a/Deeploy/Targets/GAP9/Platform.py
+++ b/Deeploy/Targets/GAP9/Platform.py
@@ -6,7 +6,7 @@ import numpy as np
 import onnx_graphsurgeon as gs
 
 from Deeploy.DeeployTypes import ConstantBuffer, DeploymentEngine, DeploymentPlatform, NetworkContext, NodeMapper, \
-    NodeTemplate, StructBuffer, TransientBuffer, VariableBuffer
+    NodeTemplate, StructBuffer, TopologyOptimizer, TransientBuffer, VariableBuffer
 from Deeploy.MemoryLevelExtension.MemoryLevels import MemoryHierarchy, MemoryLevel
 from Deeploy.MemoryLevelExtension.NetworkDeployers.MemoryLevelDeployer import MemoryPlatform, MemoryPlatformWrapper
 from Deeploy.Targets.GAP9.Templates import AllocateTemplate, FreeTemplate
@@ -22,7 +22,8 @@ from Deeploy.Targets.GAP9.Tiler import GAP9AddTilingReadyBindings, GAP9ConcatTil
     GAP9RQSTallGEMMTilingReadyBindings, GAP9RQSTilingReadyBindings, GAP9SGDTilingReadyBindings, \
     GAP9SoftmaxCrossEntropyGradTilingReadyBindings, GAP9SoftmaxCrossEntropyTilingReadyBindings, \
     GAP9SoftmaxGradTilingReadyBindings, GAP9SoftmaxTilingReadyBindings, GAP9TransposeTilingReadyBindings, \
-    GAP9UniformRQSTilingReadyBindings
+    GAP9UniformRQSTilingReadyBindings, \
+    GAP9NE16RQSGEMMTilingReadyBindings, GAP9NE16GEMMInt32TilingReadyBindings, QuantTilingReadyBindings, DeQuantTilingReadyBindings
 from Deeploy.Targets.Generic.Bindings import BasicGEMMBindings, BasicPad1DBindings, BasicPad2DBindings, \
     BasicRQIntegerDivBinding
 from Deeploy.Targets.Generic.Layers import AddLayer, ConcatLayer, ConvLayer, GatherLayer, GELULayer, GEMMLayer, \
@@ -37,12 +38,23 @@ from Deeploy.Targets.Generic.Parsers import AddParser, ConcatParser, DequantPars
     SoftmaxCrossEntropyLossGradParser, SoftmaxCrossEntropyLossParser, SoftmaxGradParser, SoftmaxParser, \
     TransposeParser, UniformRequantShiftParser, UnsqueezeParser, iHardswishParser, iRMSNormParser, iSoftmaxParser
 from Deeploy.Targets.Generic.Templates import AllocateTemplate as BasicAllocateTemplate
+from Deeploy.Targets.Generic.TopologyOptimizationPasses.Passes import DequantQuantMergePass, MatMulAddMergePass
+from Deeploy.Targets.GAP9.TopologyOptimizationPasses.Passes import NE16AdjustGEMMWeightLayoutPass
 from Deeploy.Targets.PULPOpen.Bindings import BasicDequantBindings, BasicQuantBindings, PULPDMASliceBindings, \
     PULPDWConv1DBinding, PULPReduceMeanBindings, PULPRQSConv1DBindings, PULPSliceBindings
 from Deeploy.Targets.PULPOpen.Layers import PULPRQSConvLayer, PULPRQSGEMMLayer
 from Deeploy.Targets.PULPOpen.Parsers import PULPConv1DParser, PULPConv2DParser, PULPDWConv1DParser, \
     PULPDWConv2DParser, PULPFPConv2DParser, PULPFPDWConv2DParser, PULPGEMMParser, PULPMatrixVecParser, \
     PULPTallGEMMParser
+from Deeploy.Targets.PULPOpen.Platform import PULPOptimizer
+from Deeploy.Targets.GAP9.Parsers import NE16GEMMParser
+from Deeploy.Targets.Generic.TopologyOptimizationPasses.Passes import DequantPatternPass, IntegerDivRequantMergePass, \
+    MergeConstAddAndRequantPass, MergeTrueIntegerDivRequantShiftPass, QuantPatternPass, RQSSplitPass, \
+    SkipEmptyConcatPass, SkipUnityRequantPass, iGELURequantMergePass, iHardswishRequantMergePass
+from Deeploy.Targets.PULPOpen.TopologyOptimizationPasses.Passes import PULPAddRequantMergePass, \
+    PULPConvRequantMergePass, PULPGEMMRequantMergePass, PULPMatMulRequantMergePass
+from Deeploy.CommonExtensions.OptimizationPasses.TopologyOptimizationPasses.LoweringOptimizationPasses import \
+    RemoveEmptyConvBiasPass, RemoveOnlySingletonReduceMeanPass
 
 # Create GAP9-specific NodeMappers
 GAP9_RQAddMapper = NodeMapper(RQAddParser(), GAP9RQAddTilingReadyBindings)
@@ -90,9 +102,35 @@ GAP9_SoftmaxCrossEntropyLossMapper = NodeMapper(SoftmaxCrossEntropyLossParser(),
 GAP9_SoftmaxCrossEntropyLossGradMapper = NodeMapper(SoftmaxCrossEntropyLossGradParser(),
                                                     GAP9SoftmaxCrossEntropyGradTilingReadyBindings)
 GAP9_SGDMapper = NodeMapper(SGDParser(), GAP9SGDTilingReadyBindings)
-GAP9_QuantMapper = NodeMapper(QuantParser(), BasicQuantBindings)
-GAP9_DequantMapper = NodeMapper(DequantParser(), BasicDequantBindings)
+GAP9_QuantMapper = NodeMapper(QuantParser(), QuantTilingReadyBindings)
+GAP9_DequantMapper = NodeMapper(DequantParser(), DeQuantTilingReadyBindings)
 GAP9_GEMMDequantMapper = NodeMapper(PULPGEMMParser(), BasicGEMMBindings)
+GAP9_NE16GEMMMapper = NodeMapper(NE16GEMMParser(), GAP9NE16RQSGEMMTilingReadyBindings)
+GAP9_NE16GEMMInt32Mapper = NodeMapper(GEMMParser(), GAP9NE16GEMMInt32TilingReadyBindings)
+
+GAP9Optimizer = TopologyOptimizer([
+    QuantPatternPass(),
+    DequantPatternPass(),
+    DequantQuantMergePass(),
+    MatMulAddMergePass(),
+    SkipEmptyConcatPass(),
+    SkipUnityRequantPass(previous_op_regex = "Concat", num_inputs = 2),
+    SkipUnityRequantPass(previous_op_regex = "Reshape|Transpose", num_inputs = 1),
+    SkipUnityRequantPass(previous_op_regex = "Reshape|Transpose", num_inputs = 1),
+    RQSSplitPass(),
+    MergeTrueIntegerDivRequantShiftPass(),
+    IntegerDivRequantMergePass(),
+    iGELURequantMergePass(),
+    iHardswishRequantMergePass(),
+    PULPConvRequantMergePass(),
+    MergeConstAddAndRequantPass(),
+    PULPGEMMRequantMergePass(),
+    PULPMatMulRequantMergePass(),
+    # PULPAddRequantMergePass(),
+    RemoveEmptyConvBiasPass(),
+    RemoveOnlySingletonReduceMeanPass(),
+    NE16AdjustGEMMWeightLayoutPass(),
+], name = "GAP9Optimizer")
 
 # GAP9-specific mapping using ClDma
 GAP9Mapping = {
@@ -101,9 +139,9 @@ GAP9Mapping = {
     'RequantizedConv':
         PULPRQSConvLayer([GAP9_Conv2DMapper, GAP9_DWConv2DMapper, GAP9_Conv1DMapper, GAP9_DWConv1DMapper]),
     'RequantizedGemm':
-        PULPRQSGEMMLayer([GAP9_MatrixVecMapper, GAP9_TallGEMMMapper, GAP9_GEMMMapper]),
+        PULPRQSGEMMLayer([GAP9_NE16GEMMMapper, GAP9_MatrixVecMapper, GAP9_TallGEMMMapper, GAP9_GEMMMapper]),
     'Gemm':
-        GEMMLayer([GAP9_FloatGEMMMapper, GAP9_GEMMDequantMapper]),
+        GEMMLayer([GAP9_NE16GEMMInt32Mapper, GAP9_FloatGEMMMapper, GAP9_GEMMDequantMapper]),
     'Gelu':
         GELULayer([GAP9_GELUMapper]),
     'LayerNormalization':
@@ -244,7 +282,7 @@ class GAP9StructBuffer(StructBuffer):
     deallocTemplate = NodeTemplate("")
 
 
-_includeList = ["pmsis.h", "DeeployGAP9Math.h", "pulp_nn_kernels.h", "DeeployMchan.h"]
+_includeList = ["pmsis.h", "DeeployGAP9Math.h", "pulp_nn_kernels.h", "DeeployMchan.h", "CNN_BasicKernels_fp32.h", "CNN_BasicKernels_NE16.h", "CNN_Copy.h", "ne16_utils.h"]
 
 
 class GAP9ClusterEngine(DeploymentEngine):

--- a/Deeploy/Targets/GAP9/Templates/GAP9SDKDequantQuantTemplate.py
+++ b/Deeploy/Targets/GAP9/Templates/GAP9SDKDequantQuantTemplate.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Quant/Dequant templates using GAP9 SDK kernels (CNN_Copy.c).
+# All called via GAP9Transformer which handles pi_cl_team_fork.
+
+from Deeploy.DeeployTypes import NodeTemplate
+
+# ============================================================
+# Dequant templates: int → fp16 (SDK kernels from CNN_Copy.c)
+# ============================================================
+
+# int8 → fp16: SDK kernel CNN_FpsIEEE16
+fp16DequantI8Template = NodeTemplate("""
+// FP16 Dequant int8→fp16 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _dq_infos[8];
+    *((float *)(_dq_infos + 0)) = (float)(-(${zero_point}));
+    *((float *)(_dq_infos + 4)) = (float)(${scale});
+    CNN_Quantize_T _dq_arg = {
+        .In = (void *)${data_in},
+        .Out = (void *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _dq_infos,
+    };
+    CNN_FpsIEEE16(&_dq_arg);
+}
+""")
+
+# uint8 → fp16: SDK kernel CNN_UFpsIEEE16
+fp16DequantU8Template = NodeTemplate("""
+// FP16 Dequant uint8→fp16 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _dq_infos[8];
+    *((float *)(_dq_infos + 0)) = (float)(-(${zero_point}));
+    *((float *)(_dq_infos + 4)) = (float)(${scale});
+    CNN_Quantize_T _dq_arg = {
+        .In = (void *)${data_in},
+        .Out = (void *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _dq_infos,
+    };
+    CNN_UFpsIEEE16(&_dq_arg);
+}
+""")
+
+# ============================================================
+# Dequant templates: int → fp32 (SDK kernels from CNN_Copy.c)
+# ============================================================
+
+# int8 → fp32: SDK kernel CNN_FpsFloat32
+fp32DequantI8Template = NodeTemplate("""
+// FP32 Dequant int8→fp32 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _dq_infos[8];
+    *((float *)(_dq_infos + 0)) = (float)(-(${zero_point}));
+    *((float *)(_dq_infos + 4)) = (float)(${scale});
+    CNN_FpsFloat32_T _dq_arg = {
+        .In = (signed char *)${data_in},
+        .Out = (float *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _dq_infos,
+    };
+    CNN_FpsFloat32(&_dq_arg);
+}
+""")
+
+# uint8 → fp32: SDK kernel CNN_UFpsFloat32
+fp32DequantU8Template = NodeTemplate("""
+// FP32 Dequant uint8→fp32 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _dq_infos[8];
+    *((float *)(_dq_infos + 0)) = (float)(-(${zero_point}));
+    *((float *)(_dq_infos + 4)) = (float)(${scale});
+    CNN_UFpsFloat32_T _dq_arg = {
+        .In = (unsigned char *)${data_in},
+        .Out = (float *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _dq_infos,
+    };
+    CNN_UFpsFloat32(&_dq_arg);
+}
+""")
+
+# ============================================================
+# Quant templates: fp16 → int (SDK kernels from CNN_Copy.c)
+# ============================================================
+
+# fp16 → int8: SDK kernel CNN_IEEE16Fps
+fp16QuantI8Template = NodeTemplate("""
+// FP16 Quant fp16→int8 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _q_infos[8];
+    *((float *)(_q_infos + 0)) = (float)(${zero_point});
+    *((float *)(_q_infos + 4)) = (float)(${scale});
+    CNN_Quantize_T _q_arg = {
+        .In = (void *)${data_in},
+        .Out = (void *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _q_infos,
+    };
+    CNN_IEEE16Fps(&_q_arg);
+}
+""")
+
+# fp16 → uint8: SDK kernel CNN_IEEE16UFps
+fp16QuantU8Template = NodeTemplate("""
+// FP16 Quant fp16→uint8 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _q_infos[8];
+    *((float *)(_q_infos + 0)) = (float)(${zero_point});
+    *((float *)(_q_infos + 4)) = (float)(${scale});
+    CNN_Quantize_T _q_arg = {
+        .In = (void *)${data_in},
+        .Out = (void *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _q_infos,
+    };
+    CNN_IEEE16UFps(&_q_arg);
+}
+""")
+
+# ============================================================
+# Quant templates: fp32 → int (SDK kernels from CNN_Copy.c)
+# ============================================================
+
+# fp32 → int8: SDK kernel CNN_Float32Fps
+fp32QuantI8Template = NodeTemplate("""
+// FP32 Quant fp32→int8 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _q_infos[8];
+    *((float *)(_q_infos + 0)) = (float)(${zero_point});
+    *((float *)(_q_infos + 4)) = (float)(${scale});
+    CNN_Float32Fps_T _q_arg = {
+        .In = (float *)${data_in},
+        .Out = (signed char *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _q_infos,
+    };
+    CNN_Float32Fps(&_q_arg);
+}
+""")
+
+# fp32 → uint8: SDK kernel CNN_Float32UFps
+fp32QuantU8Template = NodeTemplate("""
+// FP32 Quant fp32→uint8 (Name: ${nodeName}, Op: ${nodeOp})
+{
+    signed char _q_infos[8];
+    *((float *)(_q_infos + 0)) = (float)(${zero_point});
+    *((float *)(_q_infos + 4)) = (float)(${scale});
+    CNN_Float32UFps_T _q_arg = {
+        .In = (float *)${data_in},
+        .Out = (unsigned char *)${data_out},
+        .W = ${size},
+        .H = 1,
+        .Infos = _q_infos,
+    };
+    CNN_Float32UFps(&_q_arg);
+}
+""")

--- a/Deeploy/Targets/GAP9/Templates/NE16GEMMTemplate.py
+++ b/Deeploy/Targets/GAP9/Templates/NE16GEMMTemplate.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from Deeploy.DeeployTypes import NetworkContext, NodeTemplate, OperatorRepresentation
+
+def _ne16_conv_1x1_weight_layout(W, w_bits=8):
+    """Pack int8 weights for NE16 1x1 conv mode.
+    W: int8 [Ko, Ki] -> uint8 [Ko, Nb_KI, Qw, 2] (bitplane packed)
+    Weights stored as uint8 = int8 + 128.
+    """
+    tp_in = 16
+    Ko_, Ki_ = W.shape
+    W_uint8 = (W.astype(np.int32) + 128).astype(np.uint8)
+    nb_ki = (Ki_ + tp_in - 1) // tp_in
+    w_binary = np.zeros((Ko_ * nb_ki, w_bits, 8, tp_in // 8), dtype=np.uint8)
+    for ko in range(Ko_):
+        for ki_maj in range(nb_ki):
+            for ki_min in range(tp_in):
+                idx = ko * nb_ki + ki_maj
+                ki = ki_maj * tp_in + ki_min
+                val = int(W_uint8[ko, ki]) if ki < Ki_ else 0
+                for q in range(w_bits):
+                    w_binary[idx, q, ki_min % 8, ki_min // 8] = (val >> q) & 1
+    space = np.logspace(0, 7, num=8, base=2, dtype=np.int32).reshape((8, 1))
+    w_layout = np.sum(w_binary * space, axis=2, dtype=np.uint8)
+    return w_layout.reshape((Ko_, nb_ki, w_bits, tp_in // 8))
+
+
+class NE16GEMMTemplate(NodeTemplate):
+
+    def __init__(self, templateStr):
+        super().__init__(templateStr)
+
+    def alignToContext(self, ctxt: NetworkContext,
+                       operatorRepresentation: OperatorRepresentation) -> Tuple[NetworkContext, Dict, List[str]]:
+
+        A = ctxt.lookup(operatorRepresentation['A'])
+        B = ctxt.lookup(operatorRepresentation['B'])
+        C = ctxt.lookup(operatorRepresentation['C'])
+        data_out = ctxt.lookup(operatorRepresentation['data_out'])
+
+        # Determine signedness from type system (reliable, post-type-inference)
+        input_signed = A._type.referencedType.typeMin < 0
+        output_bits = data_out._type.referencedType.typeWidth
+        output_signed = data_out._type.referencedType.typeMin < 0
+
+        operatorRepresentation['input_signed'] = input_signed
+        operatorRepresentation['output_bits'] = output_bits
+        operatorRepresentation['quant_bits'] = 2 if output_bits == 32 else 0
+        operatorRepresentation['quant_norect'] = 1 if (output_bits == 32 or output_signed) else 0
+
+        # Weight packing and signed bias compensation
+        w_int8 = B.values.astype(np.int8)  # [Ko, Ki], still int8 at this point
+        Ko, Ki = w_int8.shape
+
+        # Truncate broadcast bias [M, O] → per-channel [Ko] for NE16
+        bias_flat = C.values.flatten()
+        if bias_flat.size > Ko:
+            C.values = bias_flat[:Ko].copy()
+
+        # Signed input bias compensation
+        if input_signed:
+            # Compute w_sum BEFORE packing (needed for signed bias compensation)
+            w_sum = w_int8.astype(np.int64).sum(axis=1)  # [Ko]
+            bias_values = C.values.flatten().astype(np.int64)
+            if 'mul' in operatorRepresentation:
+                # RequantizedGemm: bias -= 128 * w_sum * scale
+                scale_buf = ctxt.lookup(operatorRepresentation['mul'])
+                scale_values = scale_buf.values.flatten().astype(np.int64)
+                bias_values -= 128 * w_sum * scale_values
+            else:
+                # Gemm int32: bias -= 128 * w_sum (no scale)
+                bias_values -= 128 * w_sum
+            C.values = bias_values.astype(np.int32)
+
+        # Pack weights to NE16 bitplane format
+        ne16_weights = _ne16_conv_1x1_weight_layout(w_int8)
+        B.values = ne16_weights.reshape(Ko, -1)
+
+        return ctxt, operatorRepresentation, []
+
+
+# 8-bit output template (RequantizedGemm) — uses tiled ${mul} and ${scale_n}
+referenceTemplate = NE16GEMMTemplate("""
+// NE16 Linear 8-bit (Name: ${nodeName}, Op: ${nodeOp})
+
+% if input_signed:
+// Signed input: add 128 offset to convert int8 -> uint8 (multi-core SIMD)
+{
+    ne16_int8_to_uint8_T _offset_arg = {
+        .In = (int8_t *)${A},
+        .Out = (uint8_t *)${A},
+        .size = ${batch} * ${M} * ${N}
+    };
+    pi_cl_team_fork(NUM_CORES, (void *)ne16_int8_to_uint8, &_offset_arg);
+}
+% endif
+
+{
+    unsigned int _ne16_cfg = 0;
+    _ne16_cfg |= ((8 - 1)              & NE16_MASK_WBITS_M1)         << NE16_SHIFT_WBITS_M1;
+    _ne16_cfg |= (0                     & NE16_MASK_MODE16)            << NE16_SHIFT_MODE16;
+    _ne16_cfg |= (1                     & NE16_MASK_OUTQUANT)          << NE16_SHIFT_OUTQUANT;
+    _ne16_cfg |= (NE16_FILTER_MODE_1x1  & NE16_MASK_FILTER_MODE)       << NE16_SHIFT_FILTER_MODE;
+    _ne16_cfg |= (0                     & NE16_MASK_LINEAR_MODE)       << NE16_SHIFT_LINEAR_MODE;
+    _ne16_cfg |= (0                     & NE16_MASK_STRIDED_MODE)      << NE16_SHIFT_STRIDED_MODE;
+    _ne16_cfg |= (NE16_BITS_8BIT        & NE16_MASK_NORM_BITS)         << NE16_SHIFT_NORM_BITS;
+    _ne16_cfg |= (0                     & NE16_MASK_STREAMIN)          << NE16_SHIFT_STREAMIN;
+    _ne16_cfg |= (1                     & NE16_MASK_WEIGHT_OFFSET_CFG) << NE16_SHIFT_WEIGHT_OFFSET_CFG;
+    _ne16_cfg |= (0                     & NE16_MASK_QUANT_RIGHT_SHIFT) << NE16_SHIFT_QUANT_RIGHT_SHIFT;
+    _ne16_cfg |= (${quant_bits}         & NE16_MASK_QUANT_BITS)        << NE16_SHIFT_QUANT_BITS;
+    _ne16_cfg |= (${quant_norect}       & NE16_MASK_QUANT_NORECT)      << NE16_SHIFT_QUANT_NORECT;
+    _ne16_cfg |= (1                     & NE16_MASK_NORM_SHIFT)        << NE16_SHIFT_NORM_SHIFT;
+    _ne16_cfg |= (1                     & NE16_MASK_NORM_BIAS)         << NE16_SHIFT_NORM_BIAS;
+
+    NE16_Enable();
+    NE16_SoftReset();
+
+    KerConv_NE16_T _ne16_arg = {
+        .In                   = (void *)${A},
+        .Filter               = (unsigned short *)${B},
+        .Bias                 = (int *)${C},
+        .Out                  = (void *)${data_out},
+        .Scale                = (unsigned char *)${mul},
+        .ScaleN               = (unsigned char *)${scale_n},
+        .Tile_InFeat          = ${N},
+        .TotalInFeatures      = ${N},
+        .Tile_InH             = 1,
+        .Tile_InW             = ${batch} * ${M},
+        .Tile_OutFeat         = ${O},
+        .Tile_OutH            = 1,
+        .Tile_OutW            = ${batch} * ${M},
+        .FilterSize           = 1,
+        .Pad_Val              = 0,
+        .Pad                  = (v4s){0, 0, 0, 0},
+        .W_Offset             = -128,
+        .Qw                   = 8,
+        .Mode16               = 0,
+        .FirstD0              = 1,
+        .LastD0               = 1,
+        .Default_NE16_Job_Cfg = _ne16_cfg,
+        .Fx                   = 1,
+        .Fy                   = 1,
+        .Sx                   = 1,
+        .Sy                   = 1,
+        .Dx                   = 1,
+        .Dy                   = 1,
+        .BuffOut              = NULL,
+        .Infos                = NULL,
+        .Extra                = NULL,
+    };
+    KerConv1x1_SmallHW_Stride1_NE16(&_ne16_arg);
+
+    NE16_Disable();
+}
+""")
+
+# Int32 output template (plain Gemm) — hardcoded scale=1, scale_n=0
+int32OutputTemplate = NE16GEMMTemplate("""
+// NE16 Linear Int32 (Name: ${nodeName}, Op: ${nodeOp})
+
+% if input_signed:
+// Signed input: add 128 offset to convert int8 -> uint8 (multi-core SIMD)
+{
+    ne16_int8_to_uint8_T _offset_arg = {
+        .In = (int8_t *)${A},
+        .Out = (uint8_t *)${A},
+        .size = ${batch} * ${M} * ${N}
+    };
+    pi_cl_team_fork(NUM_CORES, (void *)ne16_int8_to_uint8, &_offset_arg);
+}
+% endif
+
+{
+    unsigned char _ne16_ones[${O}];
+    unsigned char _ne16_zeros[${O}];
+    memset(_ne16_ones, 1, ${O});
+    memset(_ne16_zeros, 0, ${O});
+
+    unsigned int _ne16_cfg = 0;
+    _ne16_cfg |= ((8 - 1)              & NE16_MASK_WBITS_M1)         << NE16_SHIFT_WBITS_M1;
+    _ne16_cfg |= (0                     & NE16_MASK_MODE16)            << NE16_SHIFT_MODE16;
+    _ne16_cfg |= (1                     & NE16_MASK_OUTQUANT)          << NE16_SHIFT_OUTQUANT;
+    _ne16_cfg |= (NE16_FILTER_MODE_1x1  & NE16_MASK_FILTER_MODE)       << NE16_SHIFT_FILTER_MODE;
+    _ne16_cfg |= (0                     & NE16_MASK_LINEAR_MODE)       << NE16_SHIFT_LINEAR_MODE;
+    _ne16_cfg |= (0                     & NE16_MASK_STRIDED_MODE)      << NE16_SHIFT_STRIDED_MODE;
+    _ne16_cfg |= (NE16_BITS_8BIT        & NE16_MASK_NORM_BITS)         << NE16_SHIFT_NORM_BITS;
+    _ne16_cfg |= (0                     & NE16_MASK_STREAMIN)          << NE16_SHIFT_STREAMIN;
+    _ne16_cfg |= (1                     & NE16_MASK_WEIGHT_OFFSET_CFG) << NE16_SHIFT_WEIGHT_OFFSET_CFG;
+    _ne16_cfg |= (0                     & NE16_MASK_QUANT_RIGHT_SHIFT) << NE16_SHIFT_QUANT_RIGHT_SHIFT;
+    _ne16_cfg |= (${quant_bits}         & NE16_MASK_QUANT_BITS)        << NE16_SHIFT_QUANT_BITS;
+    _ne16_cfg |= (${quant_norect}       & NE16_MASK_QUANT_NORECT)      << NE16_SHIFT_QUANT_NORECT;
+    _ne16_cfg |= (1                     & NE16_MASK_NORM_SHIFT)        << NE16_SHIFT_NORM_SHIFT;
+    _ne16_cfg |= (1                     & NE16_MASK_NORM_BIAS)         << NE16_SHIFT_NORM_BIAS;
+
+    NE16_Enable();
+    NE16_SoftReset();
+
+    KerConv_NE16_T _ne16_arg = {
+        .In                   = (void *)${A},
+        .Filter               = (unsigned short *)${B},
+        .Bias                 = (int *)${C},
+        .Out                  = (void *)${data_out},
+        .Scale                = _ne16_ones,
+        .ScaleN               = _ne16_zeros,
+        .Tile_InFeat          = ${N},
+        .TotalInFeatures      = ${N},
+        .Tile_InH             = 1,
+        .Tile_InW             = ${batch} * ${M},
+        .Tile_OutFeat         = ${O},
+        .Tile_OutH            = 1,
+        .Tile_OutW            = ${batch} * ${M},
+        .FilterSize           = 1,
+        .Pad_Val              = 0,
+        .Pad                  = (v4s){0, 0, 0, 0},
+        .W_Offset             = -128,
+        .Qw                   = 8,
+        .Mode16               = 0,
+        .FirstD0              = 1,
+        .LastD0               = 1,
+        .Default_NE16_Job_Cfg = _ne16_cfg,
+        .Fx                   = 1,
+        .Fy                   = 1,
+        .Sx                   = 1,
+        .Sy                   = 1,
+        .Dx                   = 1,
+        .Dy                   = 1,
+        .BuffOut              = NULL,
+        .Infos                = NULL,
+        .Extra                = NULL,
+    };
+    KerConv1x1_SmallHW_Stride1_NE16(&_ne16_arg);
+
+    NE16_Disable();
+}
+""")

--- a/Deeploy/Targets/GAP9/TileConstraints/NE16GEMMTileConstraint.py
+++ b/Deeploy/Targets/GAP9/TileConstraints/NE16GEMMTileConstraint.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from typing import Dict, List, Tuple
+
+from Deeploy.AbstractDataTypes import PointerClass
+from Deeploy.CommonExtensions.DataTypes import uint8_t, uint16_t
+from Deeploy.DeeployTypes import NetworkContext, OperatorRepresentation, VariableBuffer
+from Deeploy.TilingExtension.MemoryConstraints import NodeMemoryConstraint
+from Deeploy.TilingExtension.TileConstraint import TileConstraint
+from Deeploy.TilingExtension.TilerModel import PerformanceHint, TilerModel
+from Deeploy.TilingExtension.TilingCodegen import AbsoluteHyperRectangle, HyperRectangle, TilingSchedule, \
+    VariableReplacementScheme
+
+
+class NE16GEMMTileConstraint(TileConstraint):
+    """Tile constraint for NE16 GEMM with bitplane-packed weights stored as 2D [Ko, Ki]."""
+
+    @staticmethod
+    def addGeometricalConstraint(tilerModel: TilerModel, parseDict: Dict, ctxt: NetworkContext) -> TilerModel:
+
+        bufferA = ctxt.lookup(name = parseDict['A'])
+        bufferB = ctxt.lookup(name = parseDict['B'])
+        bufferC = ctxt.lookup(name = parseDict['C'])
+        outputBuffer = ctxt.lookup(name = parseDict['data_out'])
+
+        bufferNames = [bufferA.name, bufferB.name, bufferC.name, outputBuffer.name]
+        hasMul = 'mul' in parseDict and isinstance(parseDict['mul'], str)
+        if hasMul:
+            mulBuffer = ctxt.lookup(name = parseDict['mul'])
+            bufferNames.append(mulBuffer.name)
+        hasScaleN = 'scale_n' in parseDict and isinstance(parseDict['scale_n'], str)
+        if hasScaleN:
+            scaleNBuffer = ctxt.lookup(name = parseDict['scale_n'])
+            bufferNames.append(scaleNBuffer.name)
+
+        for bufferName in bufferNames:
+            tilerModel.addTensorDimToModel(ctxt, bufferName)
+
+        dimOffsetA = len(bufferA.shape) - 2
+        dimOffsetB = len(bufferB.shape) - 2
+        dimOffsetOut = len(outputBuffer.shape) - 2
+
+        AFirstDimVar = tilerModel.getTensorDimVar(tensorName = bufferA.name, dimIdx = dimOffsetA + parseDict['transA'])
+        ASecondDimVar = tilerModel.getTensorDimVar(tensorName = bufferA.name,
+                                                   dimIdx = dimOffsetA + 1 - parseDict['transA'])
+        BFirstDimVar = tilerModel.getTensorDimVar(tensorName = bufferB.name, dimIdx = dimOffsetB + parseDict['transB'])
+        BSecondDimVar = tilerModel.getTensorDimVar(tensorName = bufferB.name,
+                                                   dimIdx = dimOffsetB + 1 - parseDict['transB'])
+        outputFirstDimVar = tilerModel.getTensorDimVar(tensorName = outputBuffer.name, dimIdx = dimOffsetOut)
+        outputSecondDimVar = tilerModel.getTensorDimVar(tensorName = outputBuffer.name, dimIdx = dimOffsetOut + 1)
+
+        tilerModel.addConstraint(outputFirstDimVar == AFirstDimVar)
+        tilerModel.addConstraint(outputSecondDimVar == BSecondDimVar)
+        tilerModel.addConstraint(ASecondDimVar == BFirstDimVar)
+
+        addDimVar = tilerModel.getTensorDimVar(tensorName = bufferC.name, dimIdx = 0)
+        tilerModel.addConstraint(outputSecondDimVar == addDimVar)
+
+        if hasMul:
+            mulDimVar = tilerModel.getTensorDimVar(tensorName = mulBuffer.name, dimIdx = 0)
+            tilerModel.addConstraint(outputSecondDimVar == mulDimVar)
+
+        if hasScaleN:
+            scaleNDimVar = tilerModel.getTensorDimVar(tensorName = scaleNBuffer.name, dimIdx = 0)
+            tilerModel.addConstraint(outputSecondDimVar == scaleNDimVar)
+
+        return tilerModel
+
+    @staticmethod
+    def addPolicyConstraint(tilerModel: TilerModel, parseDict: Dict, ctxt: NetworkContext) -> TilerModel:
+
+        bufferA = ctxt.lookup(name = parseDict['A'])
+        bufferB = ctxt.lookup(name = parseDict['B'])
+
+        dimOffsetA = len(bufferA.shape) - 2
+        dimOffsetB = len(bufferB.shape) - 2
+
+        # Don't tile N (reduction dimension) — NE16 needs full input channels
+        ASecondDimVar = tilerModel.getTensorDimVar(tensorName = bufferA.name,
+                                                   dimIdx = dimOffsetA + 1 - parseDict['transA'])
+        BFirstDimVar = tilerModel.getTensorDimVar(tensorName = bufferB.name, dimIdx = dimOffsetB + parseDict['transB'])
+        tilerModel.addConstraint(ASecondDimVar == parseDict['N'])
+        tilerModel.addConstraint(BFirstDimVar == parseDict['N'])
+
+        # O (output channels) should be divisible by 32 (NE16 TP_OUT)
+        BSecondDimVar = tilerModel.getTensorDimVar(tensorName = bufferB.name,
+                                                   dimIdx = dimOffsetB + 1 - parseDict['transB'])
+        if parseDict["O"] > 32:
+            tilerModel.addTileSizeDivisibleConstraint(parseDict, 'O', BSecondDimVar, 32,
+                                                       strategy = PerformanceHint(priority = 1))
+
+        return tilerModel
+
+    @classmethod
+    def serializeTilingSolution(
+            cls, tilingSolution: NodeMemoryConstraint, absoluteOutputCubes: List[AbsoluteHyperRectangle],
+            targetMemLevel: str, ctxt: NetworkContext,
+            operatorRepresentation: OperatorRepresentation) -> Tuple[VariableReplacementScheme, TilingSchedule]:
+        outputCubes = [cube.rectangle for cube in absoluteOutputCubes]
+
+        hasMul = 'mul' in operatorRepresentation and isinstance(operatorRepresentation['mul'], str)
+        hasScaleN = 'scale_n' in operatorRepresentation and isinstance(operatorRepresentation['scale_n'], str)
+        addrNames = ['A', 'B', 'C', 'data_out']
+        if hasMul:
+            addrNames.insert(2, 'mul')
+        if hasScaleN:
+            addrNames.insert(-1, 'scale_n')
+        inputBaseOffsets, outputBaseOffsets = cls.extractBaseAddr(tilingSolution, targetMemLevel,
+                                                                  operatorRepresentation, addrNames)
+        transA = operatorRepresentation['transA']
+        transB = operatorRepresentation['transB']
+
+        buffA = ctxt.lookup(operatorRepresentation['A'])
+        buffB = ctxt.lookup(operatorRepresentation['B'])
+
+        NSize = buffA.shape[-1]
+
+        inputACubes = []
+        inputBCubes = []
+        inputMulCubes = []
+        inputAddCubes = []
+
+        replacements = {"M": [], "O": [], "batch": []}
+
+        for cube in outputCubes:
+            MOffset, OOffset = cube.offset[-2:]
+            MSize, OSize = cube.dims[-2:]
+
+            if len(cube.offset) > 2:
+                BatchSize = math.prod(cube.dims[:-2])
+            else:
+                BatchSize = 1
+
+            replacements["M"].append(MSize)
+            replacements["O"].append(OSize)
+            replacements["batch"].append(BatchSize)
+
+            if transA == 0:
+                AMatrixOffsets = (MOffset, 0)
+                AMatrixShape = (MSize, NSize)
+            else:
+                AMatrixOffsets = (0, MOffset)
+                AMatrixShape = (NSize, MSize)
+
+            if len(buffA.shape) > 2:
+                batchDimCount = len(buffA.shape) - 2
+                AMatrixOffsets = tuple(cube.offset[:-2][-batchDimCount:]) + AMatrixOffsets
+                AMatrixShape = tuple(cube.dims[:-2][-batchDimCount:]) + AMatrixShape
+
+            inputACubes.append(HyperRectangle(AMatrixOffsets, AMatrixShape))
+
+            if transB == 0:
+                BMatrixOffsets = (0, OOffset)
+                BMatrixShape = (NSize, OSize)
+            else:
+                BMatrixOffsets = (OOffset, 0)
+                BMatrixShape = (OSize, NSize)
+
+            inputBCubes.append(HyperRectangle(BMatrixOffsets, BMatrixShape))
+
+            RequantCube = HyperRectangle((OOffset,), (OSize,))
+            inputMulCubes.append(RequantCube)
+            inputAddCubes.append(RequantCube)
+
+        replacements["N"] = [NSize] * len(outputCubes)
+
+        replacementTypes = {
+            "M": PointerClass(uint16_t),
+            "N": PointerClass(uint16_t),
+            "O": PointerClass(uint16_t),
+            "batch": PointerClass(uint8_t)
+        }
+
+        inputLoadSchedule = []
+        outputLoadSchedule = []
+
+        for idx, (a, b, c) in enumerate(zip(inputACubes, inputBCubes, inputAddCubes)):
+            load = {"A": a, "B": b, "C": c}
+            if hasMul:
+                load["mul"] = inputMulCubes[idx]
+            if hasScaleN:
+                load["scale_n"] = inputMulCubes[idx]  # same per-channel slice as mul/C
+            inputLoadSchedule.append(load)
+
+        for out in outputCubes:
+            outputLoadSchedule.append({"data_out": out})
+
+        schedule = TilingSchedule(inputBaseOffsets, outputBaseOffsets, inputLoadSchedule, outputLoadSchedule)
+
+        return VariableReplacementScheme(replacements, replacementTypes), schedule

--- a/Deeploy/Targets/GAP9/Tiler.py
+++ b/Deeploy/Targets/GAP9/Tiler.py
@@ -17,7 +17,8 @@ from Deeploy.Targets.GAP9.Bindings import GAP9AddBindings, GAP9ConcatBindings, G
     GAP9RQAddBindings, GAP9RQSBindings, GAP9RQSConv2DBindings, GAP9RQSDWConv2DBindings, GAP9RQSGEMMBindings, \
     GAP9RQSiHardswishBindings, GAP9RQSMatrixVecBindings, GAP9RQSTallGEMMBindings, GAP9SGDBindings, \
     GAP9SoftmaxBindings, GAP9SoftmaxCrossEntropyLossBindings, GAP9SoftmaxCrossEntropyLossGradBindings, \
-    GAP9SoftmaxGradBindings, GAP9TransposeBindings, GAP9UniformRQSBindings
+    GAP9SoftmaxGradBindings, GAP9TransposeBindings, GAP9UniformRQSBindings, \
+    GAP9NE16RQSGEMMBindings, GAP9NE16GEMMInt32Bindings, GAP9QuantBindings, GAP9DequantBindings
 from Deeploy.Targets.Generic.TileConstraints.AddTileConstraint import AddTileConstraint
 from Deeploy.Targets.Generic.TileConstraints.ConcatTileConstraint import ConcatTileConstraint
 from Deeploy.Targets.Generic.TileConstraints.iHardswishTileConstraint import iHardswishTileConstraint
@@ -34,6 +35,7 @@ from Deeploy.Targets.PULPOpen.TileConstraints.DWConvTileConstraint import DWConv
     RQDWConv2DTileConstraint
 from Deeploy.Targets.PULPOpen.TileConstraints.GatherTileConstraint import GatherTileConstraint
 from Deeploy.Targets.PULPOpen.TileConstraints.GEMMTileConstraint import FloatGEMMTileConstraint, GEMMTileConstraint
+from Deeploy.Targets.GAP9.TileConstraints.NE16GEMMTileConstraint import NE16GEMMTileConstraint
 from Deeploy.Targets.PULPOpen.TileConstraints.iSoftmaxTileConstraint import iSoftmaxTileConstraint
 from Deeploy.Targets.PULPOpen.TileConstraints.LayernormTileConstraint import LayernormTileConstraint
 from Deeploy.Targets.PULPOpen.TileConstraints.MatMulTileConstraint import MatMulTileConstraint
@@ -59,6 +61,12 @@ GAP9DWConv2DTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9Flo
 
 GAP9RQSGEMMTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9RQSGEMMBindings,
                                                          tileConstraint = GEMMTileConstraint())
+
+GAP9NE16RQSGEMMTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9NE16RQSGEMMBindings,
+                                                              tileConstraint = NE16GEMMTileConstraint())
+
+GAP9NE16GEMMInt32TilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9NE16GEMMInt32Bindings,
+                                                                tileConstraint = NE16GEMMTileConstraint())
 
 GAP9FPGEMMTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9FloatGEMMBindings,
                                                         tileConstraint = FloatGEMMTileConstraint())
@@ -142,3 +150,10 @@ GAP9ReduceSumTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9Re
 
 GAP9SGDTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9SGDBindings,
                                                      tileConstraint = SGDTileConstraint())
+
+
+QuantTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9QuantBindings,
+                                                           tileConstraint = UnaryTileConstraint())
+
+DeQuantTilingReadyBindings = TilingReadyNodeBindings(nodeBindings = GAP9DequantBindings,
+                                                           tileConstraint = UnaryTileConstraint())

--- a/Deeploy/Targets/GAP9/TopologyOptimizationPasses/Passes.py
+++ b/Deeploy/Targets/GAP9/TopologyOptimizationPasses/Passes.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from functools import partial
+
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from Deeploy.CommonExtensions.OptimizationPasses.Matchers import Match, NonBranchingMatcher
+from Deeploy.CommonExtensions.OptimizationPasses.PassClasses import ReplaceSequentialPatternPass, contextagnostic
+
+
+def _compute_ne16_scale_shift(mul_values, log2D):
+    """Convert Deeploy's mul/log2D to NE16's per-channel scale/scale_n."""
+    Ko = len(mul_values)
+    ne16_scale = np.zeros(Ko, dtype=np.uint8)
+    ne16_scale_n = np.zeros(Ko, dtype=np.uint8)
+    for ko in range(Ko):
+        sf = float(mul_values[ko]) / float(2 ** log2D)
+        if sf >= 1.0:
+            sn = 0
+            sc = min(255, max(1, int(round(sf))))
+        elif sf > 0:
+            sn = min(31, max(0, int(math.floor(math.log2(127.0 / sf)))))
+            sc = min(255, max(1, int(round(sf * (1 << sn)))))
+        else:
+            sn = 0
+            sc = 0
+        ne16_scale[ko] = sc
+        ne16_scale_n[ko] = sn
+    return ne16_scale, ne16_scale_n
+
+
+def _ne16_adjust_gemm_weight_layout_fun(graph: gs.Graph, match: Match, name: str):
+    """Prepare GEMM node for NE16 execution.
+
+    Handles transB normalization, scale/scale_n computation, and bias rescaling.
+    Weight bitplane packing and signed bias compensation are deferred to alignToContext
+    where input signedness is known from the type system.
+    """
+    matched_nodes = list(match.nodes_map.values())
+    node = matched_nodes[0]
+
+    # Weight is input[1] for both Gemm and RequantizedGemm
+    weightTensor = node.inputs[1]
+
+    if not isinstance(weightTensor, gs.Constant):
+        return graph
+
+    values = weightTensor.values
+
+    # Skip true float weights (Deeploy stores int8 weights as float32)
+    if not np.array_equal(values, np.round(values)):
+        return graph
+
+    # Check shape is 2D
+    if len(values.shape) != 2:
+        return graph
+
+    # Determine actual Ko, Ki based on transB
+    transB = node.attrs.get('transB', 0)
+    if transB:
+        Ko, Ki = values.shape
+    else:
+        Ki, Ko = values.shape
+
+    # Check NE16 compatibility BEFORE modifying the node
+    if Ki % 16 != 0:
+        return graph
+
+    # Transpose weight to [Ko, Ki] if needed — keep as int8
+    if not transB:
+        transposed = values.T.astype(np.int8)
+        newWeightTensor = gs.Constant(f"{name}_{weightTensor.name}", transposed)
+        node.inputs[1] = newWeightTensor
+        node.attrs['transB'] = 1
+
+    # For RequantizedGemm: transform mul → ne16_scale, create scale_n, rescale bias
+    if node.op == 'RequantizedGemm' and len(node.inputs) >= 4:
+        mulTensor = node.inputs[3]
+        biasTensor = node.inputs[2]
+
+        if isinstance(mulTensor, gs.Constant) and isinstance(biasTensor, gs.Constant):
+            mul_values = mulTensor.values.flatten().astype(np.int32)
+            log2D = int(np.log2(node.attrs['div'].values))
+
+            # Broadcast scalar mul to per-channel if needed
+            if len(mul_values) == 1:
+                mul_values = np.full(Ko, mul_values[0], dtype=np.int32)
+
+            ne16_scale, ne16_scale_n = _compute_ne16_scale_shift(mul_values, log2D)
+
+            # Rescale bias from mul/log2D domain to scale/scale_n domain
+            # bias_merged is already *= mul from PULPGEMMRequantMergePass
+            # NE16 needs: bias_ne16 = bias_merged * 2^(scale_n - log2D)
+            bias_values = biasTensor.values.flatten().astype(np.int64)
+            ne16_bias = np.zeros(Ko, dtype=np.int64)
+            for ko in range(Ko):
+                shift_diff = int(ne16_scale_n[ko]) - log2D
+                if shift_diff >= 0:
+                    ne16_bias[ko] = bias_values[ko] << shift_diff
+                else:
+                    ne16_bias[ko] = bias_values[ko] >> (-shift_diff)
+
+            ne16_bias = ne16_bias.astype(np.int32)
+
+            # Overwrite mul tensor with ne16_scale
+            mulTensor.values = ne16_scale
+
+            # Overwrite bias tensor
+            biasTensor.values = ne16_bias
+
+            # Append scale_n as new input[4]
+            scale_n_tensor = gs.Constant(f"{name}_scale_n", ne16_scale_n)
+            node.inputs.append(scale_n_tensor)
+
+    return graph
+
+
+@contextagnostic
+class NE16AdjustGEMMWeightLayoutPass(ReplaceSequentialPatternPass):
+
+    def __init__(self):
+        graph = gs.Graph()
+        _input = gs.Variable(name = 'input_1')
+        output = graph.layer(inputs = [_input], outputs = ['out'], op = 'RequantizedGemm|Gemm', name = 'node')
+        graph.outputs.append(output)
+        graph.inputs.append(_input)
+
+        super().__init__(graph, _ne16_adjust_gemm_weight_layout_fun,
+                         "_NE16_ADJUST_GEMM_WEIGHT_LAYOUT_PASS",
+                         NonBranchingMatcher(regex_op = True))

--- a/Deeploy/Targets/GAP9/TopologyOptimizationPasses/__init__.py
+++ b/Deeploy/Targets/GAP9/TopologyOptimizationPasses/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/Deeploy/Targets/Generic/TopologyOptimizationPasses/Passes.py
+++ b/Deeploy/Targets/Generic/TopologyOptimizationPasses/Passes.py
@@ -1177,3 +1177,85 @@ class DequantPatternPass(ReplaceSequentialPatternPass):
 
         name = "_RECOGNIZE_DEQUANT_PASS"
         super().__init__(graph, _recognize_dequant_fun, name)
+
+
+def _merge_dequant_quant_fun(graph: gs.Graph, match: Match, name: str):
+    matched_nodes = [m for k, m in match.nodes_map.items()]
+    dequant_node = matched_nodes[0]
+    quant_node = matched_nodes[1]
+
+    # Skip if dequant output has multiple consumers or is a graph output
+    dequant_out = dequant_node.outputs[0]
+    if len(dequant_out.outputs) > 1 or dequant_out in graph.outputs:
+        return graph
+
+    # Extract Dequant parameters (stored as Python floats)
+    s_d = float(dequant_node.attrs['scale'])
+    zp_d = float(dequant_node.attrs['zero_point'])
+
+    # Extract Quant parameters (stored as numpy arrays)
+    s_q = float(np.array(quant_node.attrs['scale']).item())
+    zp_q = float(np.array(quant_node.attrs['zero_point']).item())
+
+    signed_val = int(np.array(quant_node.attrs['signed']).item()) if 'signed' in quant_node.attrs else 1
+    signed = bool(signed_val)
+    bit_width = int(np.array(quant_node.attrs['bit_width']).item()) if 'bit_width' in quant_node.attrs else 8
+    n_levels = 2 ** bit_width
+
+    # Compute effective ratio: y_float = (x_int - zp_d) * s_d * s_q + zp_q
+    ratio = s_d * s_q
+
+    # Identity case: ratio ~= 1.0, both zero points == 0
+    EPSILON = 1e-6
+    if abs(ratio - 1.0) < EPSILON and abs(zp_d) < EPSILON and abs(zp_q) < EPSILON and signed:
+        input_tensor = dequant_node.inputs[0]
+        output_tensor = quant_node.outputs[0]
+        for downstream_node in list(output_tensor.outputs):
+            for i, inp in enumerate(downstream_node.inputs):
+                if inp == output_tensor:
+                    downstream_node.inputs[i] = input_tensor
+        dequant_node.inputs.clear()
+        dequant_node.outputs.clear()
+        quant_node.inputs.clear()
+        quant_node.outputs.clear()
+        graph.cleanup().toposort()
+        return graph
+
+    # Requantization case: convert to RequantShift
+    shift = 16
+    div_val = 2 ** shift
+
+    mul_val = int(np.round(ratio * div_val))
+    add_val = int(np.round((-zp_d * ratio + zp_q) * div_val))
+
+    mul_const = gs.Constant(name = f'{name}_mul', values = np.array([mul_val], dtype = np.int32))
+    add_const = gs.Constant(name = f'{name}_add', values = np.array([add_val], dtype = np.int32))
+
+    rqs_attrs = {
+        'div': gs.Constant(f'{name}_div', np.array(div_val)),
+        'n_levels_out': gs.Constant(f'{name}_n_levels', np.array(n_levels)),
+        'signed': gs.Constant(f'{name}_signed', np.array([signed_val])),
+    }
+
+    _inputs = [dequant_node.inputs[0], mul_const, add_const]
+    _outputs = quant_node.outputs
+
+    rqs_node = gs.Node(op = 'RequantShift', name = name, attrs = rqs_attrs)
+    graph.replaceInsertNode(_inputs, _outputs, rqs_node)
+
+    return graph
+
+
+@contextagnostic
+class DequantQuantMergePass(ReplaceSequentialPatternPass):
+
+    def __init__(self):
+        graph = gs.Graph()
+        _input = gs.Variable(name = 'input_1')
+        output = graph.layer(inputs = [_input], outputs = ['dequant_out'], op = 'Dequant', name = 'dequant')
+        output = graph.layer(inputs = output, outputs = ['quant_out'], op = 'Quant', name = 'quant')
+        graph.outputs.append(output)
+        graph.inputs.append(_input)
+
+        name = "_MERGE_DEQUANT_QUANT_PASS"
+        super().__init__(graph, _merge_dequant_quant_fun, name)

--- a/Deeploy/Targets/Generic/TypeCheckers.py
+++ b/Deeploy/Targets/Generic/TypeCheckers.py
@@ -543,6 +543,15 @@ class QuantChecker(SignPropTypeChecker):
     def __init__(self, input_types: Sequence[Type[Pointer]], output_types: Sequence[Type[Pointer]]):
         super().__init__(input_types, output_types)
 
+    def checkOutputType(self, inputs: List[VariableBuffer], operatorRepresentation: OperatorRepresentation) -> bool:
+        outputTypeSigned = self.output_types[0].referencedType.typeMin < 0
+        opSigned = bool(operatorRepresentation['signed'])
+        if opSigned and outputTypeSigned:
+            return True
+        if (not opSigned) and (not outputTypeSigned):
+            return True
+        return False
+
     def _inferNumLevels(self, inputs: List[VariableBuffer],
                         operatorRepresentation: OperatorRepresentation) -> List[int]:
         # Calculate number of levels based on bit_width

--- a/DeeployTest/Platforms/GAP9/CMakeLists.txt
+++ b/DeeployTest/Platforms/GAP9/CMakeLists.txt
@@ -27,6 +27,7 @@ target_compile_options(network PRIVATE
     -Wno-pointer-sign
     -Wno-unknown-pragmas
     -Wno-error
+    -O3
   )
 
 target_link_options(${ProjectId} PRIVATE

--- a/DeeployTest/testUtils/platformMapping.py
+++ b/DeeployTest/testUtils/platformMapping.py
@@ -15,7 +15,7 @@ from Deeploy.Targets.Chimera.Platform import ChimeraOptimizer, ChimeraPlatform
 from Deeploy.Targets.CortexM.Deployer import CMSISDeployer
 from Deeploy.Targets.CortexM.Platform import CMSISOptimizer, CMSISPlatform
 from Deeploy.Targets.GAP9.Deployer import GAP9Deployer
-from Deeploy.Targets.GAP9.Platform import GAP9Platform, MemoryGAP9Platform, MemoryGAP9PlatformWrapper
+from Deeploy.Targets.GAP9.Platform import GAP9Optimizer, GAP9Platform, MemoryGAP9Platform, MemoryGAP9PlatformWrapper
 from Deeploy.Targets.Generic.Deployer import GenericDeployer
 from Deeploy.Targets.Generic.Platform import GenericOptimizer, GenericPlatform
 from Deeploy.Targets.MemPool.Deployer import MemPoolDeployer
@@ -210,7 +210,7 @@ def mapDeployer(platform: DeploymentPlatform,
     elif isinstance(platform, (GAP9Platform, MemoryGAP9Platform, MemoryGAP9PlatformWrapper)):
 
         if loweringOptimizer is None:
-            loweringOptimizer = PULPOptimizer
+            loweringOptimizer = GAP9Optimizer
 
         if default_channels_first is None:
             default_channels_first = False

--- a/TargetLibraries/GAP9/CMakeLists.txt
+++ b/TargetLibraries/GAP9/CMakeLists.txt
@@ -4,22 +4,61 @@
 
 file(GLOB_RECURSE SOURCES
   "src/**"
+  "$ENV{GAP_SDK_HOME}/tools/autotiler_v3/CNN_Libraries_fp32/CNN_Bias_Linear_Activation_fp32.c"
+  "$ENV{GAP_SDK_HOME}/tools/autotiler_v3/CNN_Libraries_NE16/CNN_BasicKernels_NE16.c"
+  "$ENV{GAP_SDK_HOME}/tools/autotiler_v3/CNN_Libraries/CNN_Copy.c"
 )
+
+
+# Exclude dory_mem and dory_dma from SOURCES (they need different optimization)
+list(FILTER SOURCES EXCLUDE REGEX ".*dory_(mem|dma).*")
 
 # RW: Include PULPOpen sources but exclude dory_mem related files
 file(GLOB_RECURSE PULPOPEN_SOURCES "../PULPOpen/src/**")
 list(FILTER PULPOPEN_SOURCES EXCLUDE REGEX ".*dory_mem.*")
 list(APPEND SOURCES ${PULPOPEN_SOURCES})
 
+# Separate dory library compiled without -O3
+add_library(dory_lib STATIC
+  ${CMAKE_CURRENT_LIST_DIR}/src/dory_mem.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/dory_dma.c
+)
+target_include_directories(dory_lib PUBLIC
+  ${CMAKE_CURRENT_LIST_DIR}/inc
+  ${CMAKE_CURRENT_LIST_DIR}/../PULPOpen/inc
+)
+target_compile_options(dory_lib PRIVATE
+  -Wno-implicit-function-declaration
+  -Wno-sign-conversion
+  -Wno-sign-compare
+  -Wno-type-limits
+  -Wno-attributes
+  -Wno-incompatible-pointer-types
+  -Og
+)
+target_compile_definitions(dory_lib PUBLIC NUM_CORES=${NUM_CORES})
+target_link_libraries(dory_lib PUBLIC pmsis)
+
 add_deeploy_library(deeploygap9 STATIC ${SOURCES})
 target_include_directories(deeploygap9
   PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}/inc
   ${CMAKE_CURRENT_LIST_DIR}/../PULPOpen/inc
+  ${TILER_INC}
+  ${TILER_EMU_INC}
+  ${TILER_CNN_KERNEL_PATH_FP32}
+  ${TILER_CNN_KERNEL_PATH_FP16}
+  $ENV{GAP_SDK_HOME}/tools/autotiler_v3/CNN_Libraries_NE16
+  $ENV{GAP_SDK_HOME}/tools/autotiler_v3/CNN_Libraries_SQ8
+  $ENV{GAP_SDK_HOME}/tools/autotiler_v3/CNN_Libraries
+  ${TILER_DSP_KERNEL_V2_PATH}
+  ${TILER_DSP_KERNEL_V2_PATH}/FastMathFunctions
 )
+
 
 target_compile_options(deeploygap9 PUBLIC
     -DNUM_CORES=${NUM_CORES}
+    -DSTD_FLOAT
   )
 
 target_compile_options(deeploygap9 PRIVATE
@@ -27,9 +66,9 @@ target_compile_options(deeploygap9 PRIVATE
   -Wno-sign-compare
   -Wno-type-limits
   -Wno-attributes
+  -Wno-incompatible-pointer-types
+  -O3
 )
-
-target_link_libraries(deeploygap9 PUBLIC pmsis)
 
 #RW: Link PULP-NN
 #RW: Set PULP-NN version and bitwidth for pulp-nn-mixed
@@ -80,5 +119,6 @@ endif()
 
 target_link_libraries(deeploygap9 PUBLIC pulp-nn-mixed)
 
+target_link_libraries(deeploygap9 PUBLIC pmsis)
 target_link_libraries(deeploygap9 PUBLIC m)
-
+target_link_libraries(deeploygap9 PUBLIC dory_lib)

--- a/TargetLibraries/GAP9/inc/ne16_utils.h
+++ b/TargetLibraries/GAP9/inc/ne16_utils.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NE16 utility kernels for GAP9
+ */
+
+#ifndef __NE16_UTILS_GAP9__
+#define __NE16_UTILS_GAP9__
+
+#include "pmsis.h"
+#include "CNN_BasicKernels_fp32.h"
+
+typedef struct {
+    int8_t *In;
+    uint8_t *Out;
+    int size;
+} ne16_int8_to_uint8_T;
+
+/* Multi-core SIMD int8 → uint8 conversion (+128 offset) */
+void ne16_int8_to_uint8(ne16_int8_to_uint8_T *Arg);
+
+#endif

--- a/TargetLibraries/GAP9/src/ne16_utils.c
+++ b/TargetLibraries/GAP9/src/ne16_utils.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NE16 utility kernels for GAP9
+ */
+
+#include "ne16_utils.h"
+
+void ne16_int8_to_uint8(ne16_int8_to_uint8_T *Arg) {
+    int8_t *In = Arg->In;
+    uint8_t *Out = Arg->Out;
+    int size = Arg->size;
+
+    unsigned int CoreId = gap_coreid();
+    unsigned int NCore = gap_ncore();
+    unsigned int total_quads = size / 4;
+    unsigned int Chunk = (total_quads + NCore - 1) / NCore;
+    unsigned int First = Chunk * CoreId;
+    unsigned int Last = First + Chunk;
+    if (Last > total_quads) Last = total_quads;
+
+    v4s offset = {-128, -128, -128, -128};
+    for (unsigned int q = First; q < Last; q++) {
+        *((v4s *)&Out[q * 4]) = *((v4s *)&In[q * 4]) + offset;
+    }
+
+    /* Handle remaining elements (size not multiple of 4) */
+    if (CoreId == 0) {
+        for (int i = total_quads * 4; i < size; i++) {
+            Out[i] = (uint8_t)((int32_t)In[i] + 128);
+        }
+    }
+}


### PR DESCRIPTION
Describe the intent of your PR here.

## Added
  - Add NE16 linear layer kernels, including a topology pass, NE16 templates, parsers, tile constraints, and bindings
  - The topology pass recognizes NE16-compatible GEMM layers, adjusts the weight layout for the NE16, and converts the requant shift/scale to the NE16 format
 - The template detects whether the input is signed; if so, it adds a +128 offset to the input during C runtime and compensates via the bias
  - Add GAP9 SDK-based Dequant/Quant templates using CNN_Copy.c kernels, replacing the generic templates
  - Add a generic DequantQuantMergePass that folds adjacent Dequant→Quant pairs into identity or RequantShift
  - Add a GAP9-specific TopologyOptimizer (GAP9Optimizer) to replace PULPOptimizer

## Changed
-

## Fixed
  - Add output signedness check in QuantChecker
- Fix L3 DMA template (add proper casts) and remove the blocking L3 DMA hack
  - Isolate dory memory functions from other libraries in CMakeLists so they compile with -Og while compute kernels compile with -O3
  - Disable PULPAddRequantMergePass due to incorrect pattern matching when Add has multiple consumers
 
## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR reviewed and approved.
3. [ ] All checks are passing.
4. [ ] The `CHANGELOG.md` file has been updated.
5. [ ] If the docker was modified, change back its link after review.
