### PR TITLE
Fix for python error when using python 3.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Fix test paths in Deeploy 101 tutorial
 - Fix tiling variable replacement corrupting static arrays by changing pointer update from value copy to address reassignment
 - Reduce RunNetwork stack usage by scoping per-layer variables with braces and moving tileIdxPtr allocation into per-layer execution blocks
+- Fix invalid escape sequence python error in DeeployTypes.py: appearing when using pytest to launch regressions
 
 ### Removed
 - `testDMA.py` was an old test; we now have `test_dmas.py` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Use Pre-Commit in CI [#159](https://github.com/pulp-platform/Deeploy/pull/159)
 - Deeploy-GAP9 Platform [#143](https://github.com/pulp-platform/Deeploy/pull/143)
 - Update CLI interface Across Project, Fix Tutorial, and Remove Legacy Test [#157](https://github.com/pulp-platform/Deeploy/pull/157)
+- Fix for python error when using python 3.12.11 [#189]( https://github.com/pulp-platform/Deeploy/pull/189)
 
 ### Added
 - Add many missing docstrings

--- a/Deeploy/DeeployTypes.py
+++ b/Deeploy/DeeployTypes.py
@@ -686,10 +686,10 @@ class NetworkContext():
 
     def _mangle(self, name: str, repr: bool = True) -> str:
         repStr = name
-        repStr = re.sub('\.', '_', repStr)
+        repStr = re.sub(r'\.', '_', repStr)
         repStr = re.sub(':', '_', repStr)
         if repr:
-            repStr = re.sub('\.', '_', self.name) + '_' + repStr
+            repStr = re.sub(r'\.', '_', self.name) + '_' + repStr
         return repStr
 
     def add(self, obj: VariableBuffer, ctxt: Literal['local', 'global'] = 'local', _id: str = ""):


### PR DESCRIPTION
This PR adds a minor fix in the Deeploy types python file. 

## Added
-

## Changed
- Added r keyword for raw string interpretation. The previous escape sequence was breaking on python 3.12.11

## Fixed
- This fixes the following error 
```
E     File "Deeploy/Deeploy/DeeployTypes.py", line 689
E       repStr = re.sub('\.', '_', repStr)
E                        ^^
E   SyntaxError: invalid escape sequence '\.'
```
## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
