### PR TITLE
Fix GAP9 L3 board tests: readfs flash ordering and duplicate input data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Update CLI interface Across Project, Fix Tutorial, and Remove Legacy Test [#157](https://github.com/pulp-platform/Deeploy/pull/157)
 - Fix for python error when using python 3.12.11 [#189]( https://github.com/pulp-platform/Deeploy/pull/189)
 - Add support for Operators for Generic target needed in MAGIA [#193]( https://github.com/pulp-platform/Deeploy/pull/193)
+- Fix GAP9 L3 Board Tests: readfs Flash Ordering and Duplicate Input Data [#196](https://github.com/pulp-platform/Deeploy/pull/196)
 
 ### Added
 - Add many missing docstrings
@@ -42,6 +43,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - PULP-NN moved to TargetLibraries third-party folder
 - Aligned CLI commands across the project
 - Added @runwangdl as a code owner
+- Skip emitting duplicate `testInputVector` data for inputs placed in L3 (loaded at runtime from the readfs hex instead), reducing test binary size
 
 ### Fixed
 - Add missing `shell: bash` directive to CI cache generation steps to ensure correct shell execution
@@ -54,6 +56,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Fix tiling variable replacement corrupting static arrays by changing pointer update from value copy to address reassignment
 - Reduce RunNetwork stack usage by scoping per-layer variables with braces and moving tileIdxPtr allocation into per-layer execution blocks
 - Fix invalid escape sequence python error in DeeployTypes.py: appearing when using pytest to launch regressions
+- Fix GAP9 board tests with `--defaultMemLevel L3` reading garbage inputs: place all gapy `--flash-property` options before the positional subcommand and use `image flash run` so the readfs partition (input hex files) is flashed to the device
 
 ### Removed
 - `testDMA.py` was an old test; we now have `test_dmas.py` instead.

--- a/DeeployTest/testUtils/codeGenerate.py
+++ b/DeeployTest/testUtils/codeGenerate.py
@@ -47,6 +47,16 @@ def generateTestInputsHeader(deployer: NetworkDeployer, test_inputs: List) -> st
         values = _shapeBroadcast(deployer.ctxt, values, bufferName)
 
         buffer = deployer.ctxt.lookup(bufferName)
+
+        # When the input lives in L3, its data is delivered at runtime from
+        # the readfs hex file (load_file_to_ram) and every L3-capable harness
+        # skips the testInputVector memcpy for external (L3) addresses. Emitting
+        # the data here would just duplicate the whole input tensor inside the
+        # binary, so keep a NULL placeholder to preserve testInputVector[]
+        # indexing without storing the data twice.
+        if getattr(buffer, "_memoryLevel", None) == "L3":
+            vectors.append("NULL")
+            continue
         typeName = buffer._type.referencedType.typeName
         typeWidth = buffer._type.referencedType.typeWidth
 

--- a/cmake/gap9/gap9_board.cmake
+++ b/cmake/gap9/gap9_board.cmake
@@ -36,22 +36,27 @@ macro(add_board_deployment name target)
         --openocd-cable=${GAP9_SDK_HOME}/utils/openocd_tools/tcl/gapuino_ftdi.cfg
         --openocd-script=${GAP9_SDK_HOME}/utils/openocd_tools/tcl/gap9revb.tcl
         --openocd-tools=${GAP9_SDK_HOME}/utils/openocd_tools
-        --binary=${DEEPLOY_BINARY}
         --work-dir=${BOARD_WORKDIR}
         --multi-flash-content=${FLASH_LAYOUT}
         --flash-size=67108864
         --flash-property=${FSBL_BINARY}@mram:fsbl:binary
         --flash-property=${SSBL_BINARY}@mram:ssbl:binary
-        --flash-property=${DEEPLOY_BINARY}@mram:app:binary run
-        --py-stack
+        --flash-property=${DEEPLOY_BINARY}@mram:app:binary
     )
 
-    # Add readfs files if provided
+    # Add readfs files if provided (MUST come before the subcommand appended below)
     if(GAPY_RUNNER_ARGS)
         list(LENGTH GAPY_RUNNER_ARGS num_readfs_files)
         message(STATUS "[Deeploy GAP9] Adding ${num_readfs_files} readfs file(s)")
         list(APPEND GAPY_CMD ${GAPY_RUNNER_ARGS})
     endif()
+
+    # Subcommand + binary go LAST, after all --flash-property options
+    list(APPEND GAPY_CMD
+        --py-stack
+        image flash run
+        --binary=${DEEPLOY_BINARY}
+    )
 
     # Convert list to string for printing
     string(REPLACE ";" " " GAPY_CMD_STR "${GAPY_CMD}")


### PR DESCRIPTION
## Fixed
- Makes GAP9 tests with `--defaultMemLevel L3` pass on the **board**. They already passed on L2 and on GVSoC; on the board every output was wrong while L2/GVSoC matched the reference.

## Testing

```
  deeployRunner_tiled_gap9.py -t
  Tests/Kernels/FP32/Add/Regular -s board --defaultMemLevel L3
```
  
  **Before**: all 64 outputs wrong (`Actual ≈ 0`).
  **After**: `Errors: 0 out of 64` on the GAP9 board. The flash log now shows `loading flash.bin_0 to spi` (readfs) and `loading mram.bin_0 to mram` before execution. L2 and GVSoC paths are unchanged.


## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
