### PR TITLE
GAP9: -O3 hot kernels; make tile-control-table memory level configurable

### DIFF
--- a/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
+++ b/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
@@ -60,7 +60,18 @@ class TilingHoistingMixIn:
         else:
             cb._type = PointerClass(BasicDataTypes.minimalIntegerType(values))
         cb._instance = cb._type(cb.name, ctxt)
-        cb._memoryLevel = self.memory
+        # These are constant tile *control* tables (numTiles / DMA cmd / size /
+        # dims / offsets) read by the (cluster) controller to drive the tiling
+        # loop and program DMAs -- not bulk tile data. Putting them in the
+        # innermost tile memory (L1/TCDM) wastes scarce L1 and, on GAP9, places
+        # them in the contended L1 region next to the cluster master stack: a
+        # deep stack write can clobber a single table entry, turning a DMA `cmd`
+        # into a garbage code pointer so mchan_transfer_wait() hangs forever
+        # (observed on MobileNetV1 training). Keep them in the controller-
+        # addressable outer memory (L2) instead. Only redirect the L2->L1 pass;
+        # the L3->L2 pass keeps its tables in L2 (== self.memory), never L3.
+        # Platforms that don't tile into a level named "L1" are unaffected.
+        cb._memoryLevel = "L2" if self.memory == "L1" else self.memory
         return cb
 
     def _hoistReference(self,

--- a/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
+++ b/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
@@ -60,18 +60,7 @@ class TilingHoistingMixIn:
         else:
             cb._type = PointerClass(BasicDataTypes.minimalIntegerType(values))
         cb._instance = cb._type(cb.name, ctxt)
-        # These are constant tile *control* tables (numTiles / DMA cmd / size /
-        # dims / offsets) read by the (cluster) controller to drive the tiling
-        # loop and program DMAs -- not bulk tile data. Putting them in the
-        # innermost tile memory (L1/TCDM) wastes scarce L1 and, on GAP9, places
-        # them in the contended L1 region next to the cluster master stack: a
-        # deep stack write can clobber a single table entry, turning a DMA `cmd`
-        # into a garbage code pointer so mchan_transfer_wait() hangs forever
-        # (observed on MobileNetV1 training). Keep them in the controller-
-        # addressable outer memory (L2) instead. Only redirect the L2->L1 pass;
-        # the L3->L2 pass keeps its tables in L2 (== self.memory), never L3.
-        # Platforms that don't tile into a level named "L1" are unaffected.
-        cb._memoryLevel = "L2" if self.memory == "L1" else self.memory
+        cb._memoryLevel = self.memory
         return cb
 
     def _hoistReference(self,

--- a/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
+++ b/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
@@ -30,6 +30,12 @@ def dictOfArrays(arrayOfDicts: Sequence[Mapping[KT, VT]]) -> Mapping[KT, List[VT
 
 class TilingHoistingMixIn:
 
+    # Where the hoisted tile-control tables (numTiles, DMA cmd / size / stride, tile dims, base
+    # offsets) go. None keeps them in the tiled level. Setting it to "L2" on GAP9 moves them away
+    # from the cluster master stack, where a deep stack write can corrupt a DMA cmd and hang
+    # mchan_transfer_wait().
+    tileControlTableMemoryLevel: Optional[str] = None
+
     _DEFAULT_HOIST_PREFIX = "TILING_CODEGEN_"
 
     def __init__(self, memory: str) -> None:
@@ -60,7 +66,7 @@ class TilingHoistingMixIn:
         else:
             cb._type = PointerClass(BasicDataTypes.minimalIntegerType(values))
         cb._instance = cb._type(cb.name, ctxt)
-        cb._memoryLevel = self.memory
+        cb._memoryLevel = self.tileControlTableMemoryLevel or self.memory
         return cb
 
     def _hoistReference(self,

--- a/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
+++ b/Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py
@@ -30,10 +30,8 @@ def dictOfArrays(arrayOfDicts: Sequence[Mapping[KT, VT]]) -> Mapping[KT, List[VT
 
 class TilingHoistingMixIn:
 
-    # Where the hoisted tile-control tables (numTiles, DMA cmd / size / stride, tile dims, base
-    # offsets) go. None keeps them in the tiled level. Setting it to "L2" on GAP9 moves them away
-    # from the cluster master stack, where a deep stack write can corrupt a DMA cmd and hang
-    # mchan_transfer_wait().
+    # JUNGVI: This attributes is here to override manually where the tiling informations are stored.
+    # It is useful for debugging purposes but too nice to expose to the CLI.
     tileControlTableMemoryLevel: Optional[str] = None
 
     _DEFAULT_HOIST_PREFIX = "TILING_CODEGEN_"

--- a/TargetLibraries/GAP9/CMakeLists.txt
+++ b/TargetLibraries/GAP9/CMakeLists.txt
@@ -31,6 +31,16 @@ target_compile_options(deeploygap9 PRIVATE
 
 target_link_libraries(deeploygap9 PUBLIC pmsis)
 
+# Compile the hot forward kernels at -O3 (set last so it wins over the SDK's
+# default -Os). Conv / depthwise-conv / Gemm dominate GAP9 inference cycles;
+# -O3 turns on the RISC-V (XpulpV2) hardware loops on their tight inner loops.
+set(_KERNEL_O3_FILES
+  ${CMAKE_CURRENT_LIST_DIR}/../PULPOpen/src/Convolution_fp32.c
+  ${CMAKE_CURRENT_LIST_DIR}/../PULPOpen/src/DWConvolution_fp32.c
+  ${CMAKE_CURRENT_LIST_DIR}/../PULPOpen/src/Gemm.c
+)
+set_source_files_properties(${_KERNEL_O3_FILES} PROPERTIES COMPILE_OPTIONS "-O3")
+
 #RW: Link PULP-NN
 #RW: Set PULP-NN version and bitwidth for pulp-nn-mixed
 set(PULPNNVERSION XPULPV2)


### PR DESCRIPTION
## 1. `-O3` on the hot forward kernels

`TargetLibraries/GAP9/CMakeLists.txt` — compile Conv / DWConv / Gemm at `-O3`, appended last so it
wins over the SDK's default `-Os`. This turns on the RISC-V (XpulpV2) hardware loops on the tight
inner loops.

## 2. Make the tile-control-table memory level configurable

`Deeploy/TilingExtension/CodeTransformationPasses/TilingHoistingMixIn.py` — adds
`tileControlTableMemoryLevel`, defaulting to `None`:

```python
cb._memoryLevel = self.tileControlTableMemoryLevel or self.memory
```

`None` is the current behaviour, so **this is a no-op unless a platform opts in**.

The hoisted tables (`numTiles`, DMA `cmd` / `size` / stride, tile dims, base offsets) are the
read-only lookup tables the controller uses to drive the tiling loop and program the DMAs. Setting
the knob to `"L2"` on GAP9 moves them out of L1 TCDM, where they otherwise sit next to the cluster
master stack — a deep stack write can corrupt a DMA `cmd` and hang `mchan_transfer_wait()` (seen on
MobileNetV1 training).