### PR TITLE
HOTFIX: XDNA2 Action Fix

### DIFF
--- a/.github/workflows/_runner-xdna2.yml
+++ b/.github/workflows/_runner-xdna2.yml
@@ -42,7 +42,6 @@ jobs:
           docker run --rm \
             --device /dev/accel/accel0 \
             --ulimit memlock=-1 \
-            -v /opt/xilinx:/opt/xilinx \
             -v "${{ github.workspace }}":/app/Deeploy \
             -w /app/Deeploy \
             ${{ inputs.docker-image }} \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 
 
 ### List of Pull Requests
+- HOTFIX: XDNA2 Action Fix [#201](https://github.com/pulp-platform/Deeploy/pull/201)
 - XDNA2 Platform Support [#179](https://github.com/pulp-platform/Deeploy/pull/179)
 - Add Microbenchmarking Infrastructure and CI Using GVSoC CSR [#162](https://github.com/pulp-platform/Deeploy/pull/162)
 - Fix CI Cache Generation [#176](https://github.com/pulp-platform/Deeploy/pull/176)
@@ -56,6 +57,8 @@ This file contains the changelog for the Deeploy project. The changelog is divid
 - Skip emitting duplicate `testInputVector` data for inputs placed in L3 (loaded at runtime from the readfs hex instead), reducing test binary size
 
 ### Fixed
+- Remove `/opt/xilinx` folder binding
+- Update XILINX_XRT env var
 - Add missing `shell: bash` directive to CI cache generation steps to ensure correct shell execution
 - Fix wrong test case in GAP9 ccache workflow (`test_gap9_tiled_kernels_l2_singlebuffer` using `MatMul/Regular` instead of `Add/Large`)
 - Fix Docker flow to fetch `*.so` git lfs files

--- a/Container/Dockerfile.deeploy-xdna
+++ b/Container/Dockerfile.deeploy-xdna
@@ -36,9 +36,9 @@ RUN apt-get update && apt-get install -y \
     libxrt-utils-npu \
     && rm -rf /var/lib/apt/lists/*
 
-ENV XILINX_XRT=/opt/xilinx/xrt
+ENV XILINX_XRT=/usr
 ENV PATH=${XILINX_XRT}/bin:${PATH}
-ENV LD_LIBRARY_PATH=${XILINX_XRT}/lib
+ENV LD_LIBRARY_PATH=${XILINX_XRT}/lib/x86_64-linux-gnu
 
 # Remove unused files and clean up to reduce image size
 WORKDIR /app


### PR DESCRIPTION
The XDNA2 container used in CI fails since I have to reset the Grays workstation, where it's self-hosted. The reason is that the `libxrt_core.so.2` libs no longer live in `/opt/xilinx` but in `/usr`. 

Passing XDNA PR with a newly generated Docker can be found [here](https://github.com/Victor-Jung/Deeploy/actions/runs/30365032116).

## Fixed
- Remove `/opt/xilinx` folder binding
- Update XILINX_XRT env var

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR reviewed and approved.
3. [x] All checks are passing.
4. [x] The `CHANGELOG.md` file has been updated.
5. [x] If the docker was modified, change back its link after review.
