### PR TITLE
Do not fetch QEMU's ROM submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,9 +530,7 @@ xtensor: ${XTENSOR_INSTALL_DIR} ${XSIMD_INSTALL_DIR}
 
 ${TOOLCHAIN_DIR}/qemu:
 	cd ${TOOLCHAIN_DIR} && \
-	git clone https://github.com/qemu/qemu.git --depth 1 -b stable-6.1 && \
-	cd ${TOOLCHAIN_DIR}/qemu && \
-	git submodule update --init --recursive
+	git clone https://github.com/qemu/qemu.git --depth 1 -b stable-6.1
 
 ${QEMU_INSTALL_DIR}: ${TOOLCHAIN_DIR}/qemu
 	cd ${TOOLCHAIN_DIR}/qemu/ && \


### PR DESCRIPTION
Fixes the toolchain build, which currently fails due to QEMU submodules.

The QEMU checkout ran `git submodule update --init --recursive`, which descends into `roms/edk2` and from there into edk2's own submodules. One of those pins cmocka to `https://git.cryptomilk.org/projects/cmocka.git`, which no longer serves a git repository, so the clone aborts.

The ROM submodules are not needed. QEMU's `configure` initialises what the build requires — `ui/keycodemapdb`, `meson`, `dtc`, `capstone`, `slirp` and the berkeley float libraries — through `scripts/git-submodule.sh`, and `roms/edk2` is not among them. Dropping the line also saves fetching ~20 firmware submodules on every image build.

## Fixed
- Do not fetch QEMU's ROM submodules when building the toolchain.